### PR TITLE
Changed docker-compose to docker compose

### DIFF
--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -48,7 +48,7 @@ services:
       - '7575:7575'
 ```
 
-Then, run ``docker-compose up -d`` in the same directory. This will start the Homarr container in the background.
+Then, run ``docker compose up -d`` in the same directory. This will start the Homarr container in the background.
 
 :::caution
 


### PR DESCRIPTION


### Category
>Bugfix

### Overview
> Changed "docker-compose" to "docker compose" as docker-compose is an alias for docker compose that doesn't exist on some platforms
