### PR TITLE
Update installation.mdx

### DIFF
--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -428,8 +428,8 @@ This method is only useful, when you want to develop on Homarr or extend it with
       <li>Clone the Repository using <code>git clone https://github.com/ajnart/homarr.git</code></li>
       <li>Enter the created directory using <code>cd homarr</code></li>
       <li>Install all dependencies using <code>yarn install</code></li>
-      <li>Build the source using <code>yarn build</code></li>
       <li>Copy the <code>example.env</code> file to <code>.env</code></li>
+      <li>Build the source using <code>yarn build</code></li>
       <li>Run <code>yarn db:migrate</code> and wait that it completes</li>
       <li>Start the NextJS web server using <code>yarn start</code></li>
       <li><i>Alternatively, use <code>yarn dev</code> to run a live development server.</i></li>
@@ -440,8 +440,8 @@ This method is only useful, when you want to develop on Homarr or extend it with
       <li>Clone the Repository using <code>git clone https://github.com/ajnart/homarr.git</code></li>
       <li>Enter the created directory using <code>cd homarr</code></li>
       <li>Install all dependencies using <code>npm install</code></li>
-      <li>Build the source using <code>npm build</code></li>
       <li>Copy the <code>example.env</code> file to <code>.env</code></li>
+      <li>Build the source using <code>npm build</code></li>
       <li>Run <code>yarn db:migrate</code> and wait that it completes</li>
       <li>Start the NextJS web server using <code>npm start</code></li>
       <li><i>Alternatively, use <code>npm run dev</code> to run a live development server.</i></li>


### PR DESCRIPTION
yarn build won't run without certain environment variables set. Moved order of operations when building from source.

### Category
Documentation

### Overview
`yarn build` won't run without certain environment variables set. Changed the order of the steps when building from source. I could not verify that `npm build` has the same issue because of some dependency error but I figured it wouldn't hurt to create the environment file before running build.

Specifically the `NEXTAUTH_URL` is marked as required.
```bash
❌ Invalid environment variables: { NEXTAUTH_URL: [ 'Required' ] }
- error Failed to load next.config.js, see more info here https://nextjs.org/docs/messages/next-config-error

> Build error occurred
Error: Invalid environment variables
    at ~/source/homarr/node_modules/@t3-oss/env-nextjs/dist/index.js:1:903
    at f (~/source/homarr/node_modules/@t3-oss/env-nextjs/dist/index.js:1:1121)
    at P (~/source/homarr/node_modules/@t3-oss/env-nextjs/dist/index.js:1:1520)
    at Object.<anonymous> (~/source/homarr/src/env.js:11:13)
    at Module._compile (node:internal/modules/cjs/loader:1378:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1437:10)
    at Module.load (node:internal/modules/cjs/loader:1212:32)
    at Module._load (node:internal/modules/cjs/loader:1028:12)
    at Module.require (node:internal/modules/cjs/loader:1237:19)
    at require (node:internal/modules/helpers:176:18)
```
