### PR TITLE
Fix link to integrations page on /dashboards/apps/

### DIFF
--- a/docs/dashboards/apps/index.md
+++ b/docs/dashboards/apps/index.md
@@ -90,4 +90,4 @@ You can choose where the app's title will be on the tile relative to the Icon.
 
 ## Integration
 
-An app may have an integration. [Integrations](https://homarr.dev/docs/integrations/) are explained here.
+An app may have an integration. [Integrations](https://homarr.dev/docs/management/integrations/) are explained here.


### PR DESCRIPTION
*Thank you for contributing to Homarr! So that your Pull Request can be handled effectively, please populate the following fields (delete sections that are not applicable)*

### Category
Documentation

### Overview
This fixes the link to the integrations page found in the Integration section of [this page](https://homarr.dev/docs/dashboards/apps/).