### PR TITLE
Fix Spelling Mistake in docs iframe explanation

### DIFF
--- a/docs/widgets/iframe/index.mdx
+++ b/docs/widgets/iframe/index.mdx
@@ -11,7 +11,7 @@ tags:
 
 If you application is not supported natively by Homarr, you can integrate it using the iframe widget.
 It uses the [iframe element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe),
-which emeds the desired page in the browser.
+which embeds the desired page in the browser.
 This means, no traffic is routed through Homarr (and the URL must be reachable from the client).
 
 Athough you can integrate many websites, some may not work.


### PR DESCRIPTION
*Thank you for contributing to Homarr! So that your Pull Request can be handled effectively, please populate the following fields (delete sections that are not applicable)*

### Category
> Documentation

### Overview
> Fixed Spelling from "emeds" to embeds in iframe explanation