### PR TITLE
docs: fix typo in 'management'

### DIFF
--- a/docs/advanced/sso.mdx
+++ b/docs/advanced/sso.mdx
@@ -1,7 +1,7 @@
 ---
 title: 🙋 Single Sign On
 tags:
-  - Managment
+  - Management
   - Users
   - Docker
   - SSO

--- a/docs/management/_category_.json
+++ b/docs/management/_category_.json
@@ -1,10 +1,10 @@
 {
-  "label": "Managment",
+  "label": "Management",
   "collapsed": true,
   "position": 2,
   "link": {
     "type": "generated-index",
-    "title": "Managment pages",
+    "title": "Management pages",
     "description": "Management pages enable you to control and adjust resources on your Homarr servers."
   }
 }

--- a/docs/management/boards/index.mdx
+++ b/docs/management/boards/index.mdx
@@ -2,7 +2,7 @@
 title: 🗃️ Boards
 sidebar_position: 1
 tags:
-  - Managment
+  - Management
   - Users
   - Docker
   - Invite

--- a/docs/management/users/index.mdx
+++ b/docs/management/users/index.mdx
@@ -2,7 +2,7 @@
 title: 👤 Users
 sidebar_position: 2
 tags:
-  - Managment
+  - Management
   - Users
   - Docker
   - Invite


### PR DESCRIPTION
### Category
Documentation

### Overview
There was a typo in the documentation, "managment" instead of "management".

### Screenshot _(if applicable)_
Old:
![image](https://github.com/user-attachments/assets/625118be-04a8-41ef-8258-16b17403184d)
New:
![image](https://github.com/user-attachments/assets/4130f196-b32d-4afc-a3fd-e2c4460e05ad)
