### PR TITLE
fix: flakey tests caused by discord banner

### DIFF
--- a/tests/screenshot.css
+++ b/tests/screenshot.css
@@ -23,8 +23,8 @@ video {
 .theme-last-updated,
     /* Dataflow is animated */
 .animated-dataflow,
-    /* Asynchronous loading images (eg. Discord server widget) */
-img[loading="lazy"],
+/* Remove discord banner */
+img[src*="discordapp.com"],
     /* Mermaid diagrams are rendered client-side and produce layout shifts */
 .docusaurus-mermaid-container {
     display: none !important;

--- a/tests/screenshot.spec.ts
+++ b/tests/screenshot.spec.ts
@@ -21,7 +21,6 @@ function screenshotPathname(pathname: string) {
     const url = siteUrl + pathname;
     await page.goto(url);
     await page.waitForFunction(waitForDocusaurusHydration);
-    await page.addStyleTag({content: stylesheet});
     await argosScreenshot(page, pathnameToArgosName(pathname), {
       argosCSS: stylesheet,
       animations: "disabled"


### PR DESCRIPTION
This fixes the flakey tests regarding the discord banner. It did not work before as described in [this](https://discord.com/channels/1001395848489484288/1287344298014281830/1287462484667535441) discord message

As we're using 

`img[loading="lazy"]` and `img[decoding="async"]` it results in running the `waitForStability` and with that the `waitForImagesToLoad` method. This method consists out of the following code:

```ts
function waitForImagesToLoad(document: Document) {
  const images = Array.from(document.images);

  // Force eager loading
  images.forEach((img) => {
    // Force sync decoding
    if (img.decoding !== 'sync') {
      img.decoding = 'sync';
    }

    // Force eager loading
    if (img.loading !== 'eager') {
      img.loading = 'eager';
    }
```

Which results in changing the attributes of those images which results in them beeing shown as they no longer apply to the rule defined in the stylesheet.