### PR TITLE
docs: add description of how to use permission system with external providers

### DIFF
--- a/docs/advanced/single-sign-on/index.mdx
+++ b/docs/advanced/single-sign-on/index.mdx
@@ -198,7 +198,11 @@ Homarr supports multiple authentication options, from internal userbase (credent
     | ``AUTH_OIDC_GROUPS_ATTRIBUTE`` | Attribute used for groups (roles) claim                  | groups        |
     | ``AUTH_OIDC_NAME_ATTRIBUTE_OVERWRITE`` | Overwrite name attribute. By default it will use preferred_username if it does not contain a `@` and otherwise name. | ---          |
 
+    ### Permission System 
 
+    To give a user special permissions, first create a new group in homarr and assign the permission desired.
+    For example if the group on homarr is called `homarr-admins` a new group on the oidc provider, for example authentik needs to be created with the same name, that would be `homarr-admins`.
+    After assigning the group on the oidc provider to the user, and logging again into homarr, the user should automatically get placed in that group and inherit the permissions defined.
 
   </TabItem>
 </Tabs>


### PR DESCRIPTION
This PR adds a section on how to setup permissions via group from oidc users