### PR TITLE
feat: rework playwright logic

### DIFF
--- a/.github/workflows/argos.yml
+++ b/.github/workflows/argos.yml
@@ -25,10 +25,11 @@ jobs:
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      - name: Install Playwright browsers
-        run: pnpm playwright install --with-deps chromium
-      - name: Build the website
-        run: pnpm docusaurus build
+      - name: Install Chrome and Build in Parallel
+        run: |
+          pnpm playwright install --with-deps chromium &
+          pnpm docusaurus build &
+          wait
       - name: Take screenshots with Playwright
         run: pnpm playwright test
       - name: Upload screenshots to Argos

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,7 @@ static/data/configs
 
 # docusaurus
 .docusaurus
+
+# CI Stuff
+screenshots
+test-results

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -72,8 +72,19 @@ const config: Config = {
         sitemap: {
           changefreq: EnumChangefreq.WEEKLY,
           priority: 0.5,
+          lastmod: 'date',
+          // Ignore all versions except the latest one
           ignorePatterns: ['/tags/**'],
           filename: 'sitemap.xml',
+          createSitemapItems: async (params) => {
+            const { defaultCreateSitemapItems, ...rest } = params;
+            const items = await defaultCreateSitemapItems(rest);
+            const filteredItems = items.filter(item => {
+              // Remove all versions except the latest onev (all the /docs/{numbers}/* and /docus/next/*)
+              return !/\/docs\/(\d+(\.\d+)*|next)\//.test(new URL(item.url).pathname);
+            });
+            return filteredItems;
+          }
         },
       } satisfies Preset.Options,
     ],

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -72,15 +72,13 @@ const config: Config = {
         sitemap: {
           changefreq: EnumChangefreq.WEEKLY,
           priority: 0.5,
-          lastmod: 'date',
-          // Ignore all versions except the latest one
           ignorePatterns: ['/tags/**'],
           filename: 'sitemap.xml',
           createSitemapItems: async (params) => {
             const { defaultCreateSitemapItems, ...rest } = params;
             const items = await defaultCreateSitemapItems(rest);
             const filteredItems = items.filter(item => {
-              // Remove all versions except the latest onev (all the /docs/{numbers}/* and /docus/next/*)
+              // Remove all versions except the latest one (all the /docs/{numbers}/* and /docus/next/*)
               return !/\/docs\/(\d+(\.\d+)*|next)\//.test(new URL(item.url).pathname);
             });
             return filteredItems;

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,12 +4,14 @@ import type {PlaywrightTestConfig} from '@playwright/test';
 const config: PlaywrightTestConfig = {
   webServer: {
     port: 3000,
-    command: 'yarn docusaurus serve',
+    command: 'pnpm docusaurus serve',
   },
   use: {
     trace: 'on-first-retry',
     screenshot: "only-on-failure",
   },
+  workers: "100%",
+  fullyParallel: true,
   projects: [
     {
       name: 'chromium',

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -10,7 +10,11 @@ export function extractSitemapPathnames(sitemapPath: string): string[] {
   $('loc').each(function handleLoc() {
     urls.push($(this).text());
   });
-  return urls.map((url) => new URL(url).pathname);
+  const filteredUrls = urls.filter((url) => {
+    // Remove all the /docs/tags/* urls
+    return !/\/docs\/tags\/.*$/.test(url);
+  });
+  return filteredUrls.map((url) => new URL(url).pathname);
 }
 
 // Converts a pathname to a decent screenshot name

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -11,8 +11,8 @@ export function extractSitemapPathnames(sitemapPath: string): string[] {
     urls.push($(this).text());
   });
   const filteredUrls = urls.filter((url) => {
-    // Remove all the /docs/tags/* urls
-    return !/\/docs\/tags\/.*$/.test(url);
+    // Remove all the /docs/tags/* urls and the /blog/tags/
+    return !url.includes('/docs/tags/') && !url.includes('/blog/tags/');
   });
   return filteredUrls.map((url) => new URL(url).pathname);
 }


### PR DESCRIPTION
Make playwright use 100% of CI resources (all cores), it defaults to 50% 
<img width="735" alt="image" src="https://github.com/user-attachments/assets/36f62642-6bde-41fd-86eb-8488dcb8e9c6" />


https://playwright.dev/docs/test-parallel

https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-sitemap


- Revisit sitemap to not index older versions (all except the latest one will be indexed by google search, because duplicated content is penalized) 
- Exclude /tags/ from playwright, because they are not actually content pages
- Parallelize playwright worker
- Increase number of playwright workers to 100% of available CPUs 


## TLDR; 30 mins of screenshots turned into 45 seconds on my machine
