### PR TITLE
Add admin permisions disclaimer to hardware.mdx

### DIFF
--- a/docs/integrations/hardware.mdx
+++ b/docs/integrations/hardware.mdx
@@ -15,6 +15,10 @@ The OpenMediaVault integration allows you to view performance and resource data 
 - [System Health Monitoring](/docs/widgets/health-monitoring)
   - To use this widget, you must have the OpenMediaVault plugin `openmediavault-cputemp` installed.
 
+:::caution
+The user used here must have administrative permisions or Homarr won't be able to read the system performance and resource data.
+:::
+
 <details>
   <summary>
   Available configuration options


### PR DESCRIPTION
I've added a caution tag with the admin permissions required disclaimer to the OMV section

Fixes #291