### PR TITLE
docs(installation): update from source for v1.27.0

### DIFF
--- a/docs/getting-started/installation/source.mdx
+++ b/docs/getting-started/installation/source.mdx
@@ -33,6 +33,7 @@ This method is only useful, when you want to develop on Homarr or extend it with
   <li>Install all dependencies using <code>pnpm install</code></li>
   <li>Copy the `.env.example` file to `.env` and replace `DB_URL` with the full path you want to use for the sqlite database file. For example `DB_URL='/home/username/homarr/db.sqlite`</li>
   <li>Replace `AUTH_SECRET` and `SECRET_ENCRYPTION_KEY` both with a secure random string by using `openssl rand -hex 32`</li>
+  <li>Replace `CRON_JOB_API_KEY` with a secure random string by using `openssl rand -base64 32`</li>
   <li>Run `pnpm run db:migration:sqlite:run` and wait that it completes</li>
   <li>Build the source using `pnpm build`</li>
   <li>Copy better-sqlite3.node files with `mkdir build` and `cp ./node_modules/better-sqlite3/build/Release/better_sqlite3.node ./build/better_sqlite3.node`</li>


### PR DESCRIPTION
Update installation from source:
`CRON_JOB_API_KEY` is reqired from v1.27.0.
Other environment such as docker container is defined in dockerfile, so it's not need in .env.
But from source, we need it (or export from commandline).