### PR TITLE
feat: add Chinese localization and update home hero component

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -17,7 +17,17 @@ const config: Config = {
   // Has to be set even if not using translations
   i18n: {
     defaultLocale: 'en',
-    locales: ['en'],
+    locales: ['en', 'cn'],
+    localeConfigs: {
+      en: {
+        label: 'English',
+        htmlLang: 'en-GB',
+      },
+      cn: {
+        label: '简体中文',
+        htmlLang: 'zh-Hans',
+      },
+    },
   },
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'throw',
@@ -117,6 +127,10 @@ const config: Config = {
           label: 'About us',
           position: 'left',
           to: '/about-us',
+        },
+        {
+          type: 'localeDropdown',
+          position: 'right',
         },
         /*{
           to: 'https://demo.homarr.dev/',

--- a/i18n/cn/code.json
+++ b/i18n/cn/code.json
@@ -1,0 +1,459 @@
+{
+  "theme.NotFound.title": {
+    "message": "Page Not Found",
+    "description": "The title of the 404 page"
+  },
+  "theme.NotFound.p1": {
+    "message": "We could not find what you were looking for.",
+    "description": "The first paragraph of the 404 page"
+  },
+  "A sleek, modern dashboard that puts all of your apps and services at your fingertips. Control everything in one convenient location. Seamlessly integrates with the apps you've added, providing you with valuable information.": {
+    "message": "光滑的现代仪表板，将所有应用程序和服务触手可及。在一个方便的位置控制所有内容。与您添加的应用程序无缝集成，为您提供有价值的信息。"
+  },
+  "theme.ErrorPageContent.title": {
+    "message": "This page crashed.",
+    "description": "The title of the fallback page when the page crashed"
+  },
+  "theme.BackToTopButton.buttonAriaLabel": {
+    "message": "Scroll back to top",
+    "description": "The ARIA label for the back to top button"
+  },
+  "theme.blog.archive.title": {
+    "message": "Archive",
+    "description": "The page & hero title of the blog archive page"
+  },
+  "theme.blog.archive.description": {
+    "message": "Archive",
+    "description": "The page & hero description of the blog archive page"
+  },
+  "theme.blog.paginator.navAriaLabel": {
+    "message": "Blog list page navigation",
+    "description": "The ARIA label for the blog pagination"
+  },
+  "theme.blog.paginator.newerEntries": {
+    "message": "Newer entries",
+    "description": "The label used to navigate to the newer blog posts page (previous page)"
+  },
+  "theme.blog.paginator.olderEntries": {
+    "message": "Older entries",
+    "description": "The label used to navigate to the older blog posts page (next page)"
+  },
+  "theme.blog.post.paginator.navAriaLabel": {
+    "message": "Blog post page navigation",
+    "description": "The ARIA label for the blog posts pagination"
+  },
+  "theme.blog.post.paginator.newerPost": {
+    "message": "Newer post",
+    "description": "The blog post button label to navigate to the newer/previous post"
+  },
+  "theme.blog.post.paginator.olderPost": {
+    "message": "Older post",
+    "description": "The blog post button label to navigate to the older/next post"
+  },
+  "theme.tags.tagsPageLink": {
+    "message": "View all tags",
+    "description": "The label of the link targeting the tag list page"
+  },
+  "theme.colorToggle.ariaLabel.mode.system": {
+    "message": "system mode",
+    "description": "The name for the system color mode"
+  },
+  "theme.colorToggle.ariaLabel.mode.light": {
+    "message": "light mode",
+    "description": "The name for the light color mode"
+  },
+  "theme.colorToggle.ariaLabel.mode.dark": {
+    "message": "dark mode",
+    "description": "The name for the dark color mode"
+  },
+  "theme.colorToggle.ariaLabel": {
+    "message": "Switch between dark and light mode (currently {mode})",
+    "description": "The ARIA label for the color mode toggle"
+  },
+  "theme.docs.breadcrumbs.navAriaLabel": {
+    "message": "Breadcrumbs",
+    "description": "The ARIA label for the breadcrumbs"
+  },
+  "theme.docs.DocCard.categoryDescription.plurals": {
+    "message": "1 item|{count} items",
+    "description": "The default description for a category card in the generated index about how many items this category includes"
+  },
+  "theme.docs.paginator.navAriaLabel": {
+    "message": "Docs pages",
+    "description": "The ARIA label for the docs pagination"
+  },
+  "theme.docs.paginator.previous": {
+    "message": "Previous",
+    "description": "The label used to navigate to the previous doc"
+  },
+  "theme.docs.paginator.next": {
+    "message": "Next",
+    "description": "The label used to navigate to the next doc"
+  },
+  "theme.docs.tagDocListPageTitle.nDocsTagged": {
+    "message": "One doc tagged|{count} docs tagged",
+    "description": "Pluralized label for \"{count} docs tagged\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.docs.tagDocListPageTitle": {
+    "message": "{nDocsTagged} with \"{tagName}\"",
+    "description": "The title of the page for a docs tag"
+  },
+  "theme.common.editThisPage": {
+    "message": "Edit this page",
+    "description": "The link label to edit the current page"
+  },
+  "theme.docs.versions.unreleasedVersionLabel": {
+    "message": "This is unreleased documentation for {siteTitle} {versionLabel} version.",
+    "description": "The label used to tell the user that he's browsing an unreleased doc version"
+  },
+  "theme.docs.versions.unmaintainedVersionLabel": {
+    "message": "This is documentation for {siteTitle} {versionLabel}, which is no longer actively maintained.",
+    "description": "The label used to tell the user that he's browsing an unmaintained doc version"
+  },
+  "theme.docs.versions.latestVersionSuggestionLabel": {
+    "message": "For up-to-date documentation, see the {latestVersionLink} ({versionLabel}).",
+    "description": "The label used to tell the user to check the latest version"
+  },
+  "theme.docs.versions.latestVersionLinkLabel": {
+    "message": "latest version",
+    "description": "The label used for the latest version suggestion link label"
+  },
+  "theme.common.headingLinkTitle": {
+    "message": "Direct link to {heading}",
+    "description": "Title for link to heading"
+  },
+  "theme.docs.versionBadge.label": {
+    "message": "Version: {versionLabel}"
+  },
+  "theme.lastUpdated.atDate": {
+    "message": " on {date}",
+    "description": "The words used to describe on which date a page has been last updated"
+  },
+  "theme.lastUpdated.byUser": {
+    "message": " by {user}",
+    "description": "The words used to describe by who the page has been last updated"
+  },
+  "theme.lastUpdated.lastUpdatedAtBy": {
+    "message": "Last updated{atDate}{byUser}",
+    "description": "The sentence used to display when a page has been last updated, and by who"
+  },
+  "theme.navbar.mobileVersionsDropdown.label": {
+    "message": "Versions",
+    "description": "The label for the navbar versions dropdown on mobile view"
+  },
+  "theme.tags.tagsListLabel": {
+    "message": "Tags:",
+    "description": "The label alongside a tag list"
+  },
+  "theme.admonition.caution": {
+    "message": "caution",
+    "description": "The default label used for the Caution admonition (:::caution)"
+  },
+  "theme.admonition.danger": {
+    "message": "danger",
+    "description": "The default label used for the Danger admonition (:::danger)"
+  },
+  "theme.admonition.info": {
+    "message": "info",
+    "description": "The default label used for the Info admonition (:::info)"
+  },
+  "theme.admonition.note": {
+    "message": "note",
+    "description": "The default label used for the Note admonition (:::note)"
+  },
+  "theme.admonition.tip": {
+    "message": "tip",
+    "description": "The default label used for the Tip admonition (:::tip)"
+  },
+  "theme.admonition.warning": {
+    "message": "warning",
+    "description": "The default label used for the Warning admonition (:::warning)"
+  },
+  "theme.AnnouncementBar.closeButtonAriaLabel": {
+    "message": "Close",
+    "description": "The ARIA label for close button of announcement bar"
+  },
+  "theme.blog.sidebar.navAriaLabel": {
+    "message": "Blog recent posts navigation",
+    "description": "The ARIA label for recent posts in the blog sidebar"
+  },
+  "theme.DocSidebarItem.expandCategoryAriaLabel": {
+    "message": "Expand sidebar category '{label}'",
+    "description": "The ARIA label to expand the sidebar category"
+  },
+  "theme.DocSidebarItem.collapseCategoryAriaLabel": {
+    "message": "Collapse sidebar category '{label}'",
+    "description": "The ARIA label to collapse the sidebar category"
+  },
+  "theme.NotFound.p2": {
+    "message": "Please contact the owner of the site that linked you to the original URL and let them know their link is broken.",
+    "description": "The 2nd paragraph of the 404 page"
+  },
+  "theme.NavBar.navAriaLabel": {
+    "message": "Main",
+    "description": "The ARIA label for the main navigation"
+  },
+  "theme.TOCCollapsible.toggleButtonLabel": {
+    "message": "On this page",
+    "description": "The label used by the button on the collapsible TOC component"
+  },
+  "theme.navbar.mobileLanguageDropdown.label": {
+    "message": "Languages",
+    "description": "The label for the mobile language switcher dropdown"
+  },
+  "theme.blog.post.readMore": {
+    "message": "Read more",
+    "description": "The label used in blog post item excerpts to link to full blog posts"
+  },
+  "theme.blog.post.readMoreLabel": {
+    "message": "Read more about {title}",
+    "description": "The ARIA label for the link to full blog posts from excerpts"
+  },
+  "theme.CodeBlock.copy": {
+    "message": "Copy",
+    "description": "The copy button label on code blocks"
+  },
+  "theme.CodeBlock.copied": {
+    "message": "Copied",
+    "description": "The copied button label on code blocks"
+  },
+  "theme.CodeBlock.copyButtonAriaLabel": {
+    "message": "Copy code to clipboard",
+    "description": "The ARIA label for copy code blocks button"
+  },
+  "theme.CodeBlock.wordWrapToggle": {
+    "message": "Toggle word wrap",
+    "description": "The title attribute for toggle word wrapping button of code block lines"
+  },
+  "theme.docs.breadcrumbs.home": {
+    "message": "Home page",
+    "description": "The ARIA label for the home page in the breadcrumbs"
+  },
+  "theme.blog.post.readingTime.plurals": {
+    "message": "One min read|{readingTime} min read",
+    "description": "Pluralized label for \"{readingTime} min read\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.docs.sidebar.collapseButtonTitle": {
+    "message": "Collapse sidebar",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.docs.sidebar.collapseButtonAriaLabel": {
+    "message": "Collapse sidebar",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.docs.sidebar.navAriaLabel": {
+    "message": "Docs sidebar",
+    "description": "The ARIA label for the sidebar navigation"
+  },
+  "theme.docs.sidebar.closeSidebarButtonAriaLabel": {
+    "message": "Close navigation bar",
+    "description": "The ARIA label for close button of mobile sidebar"
+  },
+  "theme.navbar.mobileSidebarSecondaryMenu.backButtonLabel": {
+    "message": "← Back to main menu",
+    "description": "The label of the back button to return to main menu, inside the mobile navbar sidebar secondary menu (notably used to display the docs sidebar)"
+  },
+  "theme.docs.sidebar.toggleSidebarButtonAriaLabel": {
+    "message": "Toggle navigation bar",
+    "description": "The ARIA label for hamburger menu button of mobile navigation"
+  },
+  "theme.navbar.mobileDropdown.collapseButton.expandAriaLabel": {
+    "message": "Expand the dropdown",
+    "description": "The ARIA label of the button to expand the mobile dropdown navbar item"
+  },
+  "theme.navbar.mobileDropdown.collapseButton.collapseAriaLabel": {
+    "message": "Collapse the dropdown",
+    "description": "The ARIA label of the button to collapse the mobile dropdown navbar item"
+  },
+  "theme.docs.sidebar.expandButtonTitle": {
+    "message": "Expand sidebar",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
+  },
+  "theme.docs.sidebar.expandButtonAriaLabel": {
+    "message": "Expand sidebar",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
+  },
+  "theme.SearchBar.seeAll": {
+    "message": "See all {count} results"
+  },
+  "theme.SearchPage.documentsFound.plurals": {
+    "message": "One document found|{count} documents found",
+    "description": "Pluralized label for \"{count} documents found\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.SearchPage.existingResultsTitle": {
+    "message": "Search results for \"{query}\"",
+    "description": "The search page title for non-empty query"
+  },
+  "theme.SearchPage.emptyResultsTitle": {
+    "message": "Search the documentation",
+    "description": "The search page title for empty query"
+  },
+  "theme.SearchPage.inputPlaceholder": {
+    "message": "Type your search here",
+    "description": "The placeholder for search page input"
+  },
+  "theme.SearchPage.inputLabel": {
+    "message": "Search",
+    "description": "The ARIA label for search page input"
+  },
+  "theme.SearchPage.algoliaLabel": {
+    "message": "Search by Algolia",
+    "description": "The ARIA label for Algolia mention"
+  },
+  "theme.SearchPage.noResultsText": {
+    "message": "No results were found",
+    "description": "The paragraph for empty search result"
+  },
+  "theme.SearchPage.fetchingNewResults": {
+    "message": "Fetching new results...",
+    "description": "The paragraph for fetching new search results"
+  },
+  "theme.SearchBar.label": {
+    "message": "Search",
+    "description": "The ARIA label and placeholder for search button"
+  },
+  "theme.SearchModal.searchBox.resetButtonTitle": {
+    "message": "Clear the query",
+    "description": "The label and ARIA label for search box reset button"
+  },
+  "theme.SearchModal.searchBox.cancelButtonText": {
+    "message": "Cancel",
+    "description": "The label and ARIA label for search box cancel button"
+  },
+  "theme.SearchModal.startScreen.recentSearchesTitle": {
+    "message": "Recent",
+    "description": "The title for recent searches"
+  },
+  "theme.SearchModal.startScreen.noRecentSearchesText": {
+    "message": "No recent searches",
+    "description": "The text when no recent searches"
+  },
+  "theme.SearchModal.startScreen.saveRecentSearchButtonTitle": {
+    "message": "Save this search",
+    "description": "The label for save recent search button"
+  },
+  "theme.SearchModal.startScreen.removeRecentSearchButtonTitle": {
+    "message": "Remove this search from history",
+    "description": "The label for remove recent search button"
+  },
+  "theme.SearchModal.startScreen.favoriteSearchesTitle": {
+    "message": "Favorite",
+    "description": "The title for favorite searches"
+  },
+  "theme.SearchModal.startScreen.removeFavoriteSearchButtonTitle": {
+    "message": "Remove this search from favorites",
+    "description": "The label for remove favorite search button"
+  },
+  "theme.SearchModal.errorScreen.titleText": {
+    "message": "Unable to fetch results",
+    "description": "The title for error screen of search modal"
+  },
+  "theme.SearchModal.errorScreen.helpText": {
+    "message": "You might want to check your network connection.",
+    "description": "The help text for error screen of search modal"
+  },
+  "theme.SearchModal.footer.selectText": {
+    "message": "to select",
+    "description": "The explanatory text of the action for the enter key"
+  },
+  "theme.SearchModal.footer.selectKeyAriaLabel": {
+    "message": "Enter key",
+    "description": "The ARIA label for the Enter key button that makes the selection"
+  },
+  "theme.SearchModal.footer.navigateText": {
+    "message": "to navigate",
+    "description": "The explanatory text of the action for the Arrow up and Arrow down key"
+  },
+  "theme.SearchModal.footer.navigateUpKeyAriaLabel": {
+    "message": "Arrow up",
+    "description": "The ARIA label for the Arrow up key button that makes the navigation"
+  },
+  "theme.SearchModal.footer.navigateDownKeyAriaLabel": {
+    "message": "Arrow down",
+    "description": "The ARIA label for the Arrow down key button that makes the navigation"
+  },
+  "theme.SearchModal.footer.closeText": {
+    "message": "to close",
+    "description": "The explanatory text of the action for Escape key"
+  },
+  "theme.SearchModal.footer.closeKeyAriaLabel": {
+    "message": "Escape key",
+    "description": "The ARIA label for the Escape key button that close the modal"
+  },
+  "theme.SearchModal.footer.searchByText": {
+    "message": "Search by",
+    "description": "The text explain that the search is making by Algolia"
+  },
+  "theme.SearchModal.noResultsScreen.noResultsText": {
+    "message": "No results for",
+    "description": "The text explains that there are no results for the following search"
+  },
+  "theme.SearchModal.noResultsScreen.suggestedQueryText": {
+    "message": "Try searching for",
+    "description": "The text for the suggested query when no results are found for the following search"
+  },
+  "theme.SearchModal.noResultsScreen.reportMissingResultsText": {
+    "message": "Believe this query should return results?",
+    "description": "The text for the question where the user thinks there are missing results"
+  },
+  "theme.SearchModal.noResultsScreen.reportMissingResultsLinkText": {
+    "message": "Let us know.",
+    "description": "The text for the link to report missing results"
+  },
+  "theme.SearchModal.placeholder": {
+    "message": "Search docs",
+    "description": "The placeholder of the input of the DocSearch pop-up modal"
+  },
+  "theme.blog.post.plurals": {
+    "message": "One post|{count} posts",
+    "description": "Pluralized label for \"{count} posts\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.blog.tagTitle": {
+    "message": "{nPosts} tagged with \"{tagName}\"",
+    "description": "The title of the page for a blog tag"
+  },
+  "theme.blog.author.pageTitle": {
+    "message": "{authorName} - {nPosts}",
+    "description": "The title of the page for a blog author"
+  },
+  "theme.blog.authorsList.pageTitle": {
+    "message": "Authors",
+    "description": "The title of the authors page"
+  },
+  "theme.blog.authorsList.viewAll": {
+    "message": "View all authors",
+    "description": "The label of the link targeting the blog authors page"
+  },
+  "theme.blog.author.noPosts": {
+    "message": "This author has not written any posts yet.",
+    "description": "The text for authors with 0 blog post"
+  },
+  "theme.contentVisibility.unlistedBanner.title": {
+    "message": "Unlisted page",
+    "description": "The unlisted content banner title"
+  },
+  "theme.contentVisibility.unlistedBanner.message": {
+    "message": "This page is unlisted. Search engines will not index it, and only users having a direct link can access it.",
+    "description": "The unlisted content banner message"
+  },
+  "theme.contentVisibility.draftBanner.title": {
+    "message": "Draft page",
+    "description": "The draft content banner title"
+  },
+  "theme.contentVisibility.draftBanner.message": {
+    "message": "This page is a draft. It will only be visible in dev and be excluded from the production build.",
+    "description": "The draft content banner message"
+  },
+  "theme.ErrorPageContent.tryAgain": {
+    "message": "Try again",
+    "description": "The label of the button to try again rendering when the React error boundary captures an error"
+  },
+  "theme.common.skipToMainContent": {
+    "message": "Skip to main content",
+    "description": "The skip to content label used for accessibility, allowing to rapidly navigate to main content with keyboard tab/enter navigation"
+  },
+  "theme.tags.tagsPageTitle": {
+    "message": "Tags",
+    "description": "The title of the tag list page"
+  }
+}

--- a/i18n/cn/docusaurus-plugin-content-blog/options.json
+++ b/i18n/cn/docusaurus-plugin-content-blog/options.json
@@ -1,0 +1,14 @@
+{
+  "title": {
+    "message": "Blog",
+    "description": "The title for the blog used in SEO"
+  },
+  "description": {
+    "message": "Blog",
+    "description": "The description for the blog used in SEO"
+  },
+  "sidebar.title": {
+    "message": "Recent posts",
+    "description": "The label for the left sidebar"
+  }
+}

--- a/i18n/cn/docusaurus-plugin-content-docs/current.json
+++ b/i18n/cn/docusaurus-plugin-content-docs/current.json
@@ -1,0 +1,82 @@
+{
+  "version.label": {
+    "message": "Next",
+    "description": "The label for version current"
+  },
+  "sidebar.GettingStarted.category.Installation": {
+    "message": "Installation",
+    "description": "The label for category Installation in sidebar GettingStarted"
+  },
+  "sidebar.GettingStarted.category.Installation.link.generated-index.title": {
+    "message": "Getting started",
+    "description": "The generated-index page title for category Installation in sidebar GettingStarted"
+  },
+  "sidebar.Docs.category.Getting started": {
+    "message": "Getting started",
+    "description": "The label for category Getting started in sidebar Docs"
+  },
+  "sidebar.Docs.category.Getting started.link.generated-index.title": {
+    "message": "Getting started",
+    "description": "The generated-index page title for category Getting started in sidebar Docs"
+  },
+  "sidebar.Docs.category.Installation": {
+    "message": "Installation",
+    "description": "The label for category Installation in sidebar Docs"
+  },
+  "sidebar.Docs.category.Installation.link.generated-index.title": {
+    "message": "Getting started",
+    "description": "The generated-index page title for category Installation in sidebar Docs"
+  },
+  "sidebar.Docs.category.Management": {
+    "message": "Management",
+    "description": "The label for category Management in sidebar Docs"
+  },
+  "sidebar.Docs.category.Management.link.generated-index.title": {
+    "message": "Management pages",
+    "description": "The generated-index page title for category Management in sidebar Docs"
+  },
+  "sidebar.Docs.category.Integrations": {
+    "message": "Integrations",
+    "description": "The label for category Integrations in sidebar Docs"
+  },
+  "sidebar.Docs.category.Integrations.link.generated-index.title": {
+    "message": "Integrations",
+    "description": "The generated-index page title for category Integrations in sidebar Docs"
+  },
+  "sidebar.Docs.category.Integrations.link.generated-index.description": {
+    "message": "Integration are a principal part of homarr, it's where you can connect your other apps to interact with them with widgets or other capabilities, Homarr currently integrates with the following applications:",
+    "description": "The generated-index page description for category Integrations in sidebar Docs"
+  },
+  "sidebar.Docs.category.Widgets": {
+    "message": "Widgets",
+    "description": "The label for category Widgets in sidebar Docs"
+  },
+  "sidebar.Docs.category.Widgets.link.generated-index.title": {
+    "message": "Widgets",
+    "description": "The generated-index page title for category Widgets in sidebar Docs"
+  },
+  "sidebar.Docs.category.Widgets.link.generated-index.description": {
+    "message": "Widgets allow you to show data on your board or control applications. Click on one of the widgets below for further information:",
+    "description": "The generated-index page description for category Widgets in sidebar Docs"
+  },
+  "sidebar.Docs.category.Advanced": {
+    "message": "Advanced",
+    "description": "The label for category Advanced in sidebar Docs"
+  },
+  "sidebar.Docs.category.Advanced.link.generated-index.title": {
+    "message": "Advanced Concepts or features",
+    "description": "The generated-index page title for category Advanced in sidebar Docs"
+  },
+  "sidebar.Docs.category.Developer guides": {
+    "message": "Developer guides",
+    "description": "The label for category Developer guides in sidebar Docs"
+  },
+  "sidebar.Docs.category.Command line interface": {
+    "message": "Command line interface",
+    "description": "The label for category Command line interface in sidebar Docs"
+  },
+  "sidebar.Docs.category.Community": {
+    "message": "Community",
+    "description": "The label for category Community in sidebar Docs"
+  }
+}

--- a/i18n/cn/docusaurus-plugin-content-docs/version-1.10.0.json
+++ b/i18n/cn/docusaurus-plugin-content-docs/version-1.10.0.json
@@ -1,0 +1,82 @@
+{
+  "version.label": {
+    "message": "1.10.0",
+    "description": "The label for version 1.10.0"
+  },
+  "sidebar.GettingStarted.category.Installation": {
+    "message": "Installation",
+    "description": "The label for category Installation in sidebar GettingStarted"
+  },
+  "sidebar.GettingStarted.category.Installation.link.generated-index.title": {
+    "message": "Getting started",
+    "description": "The generated-index page title for category Installation in sidebar GettingStarted"
+  },
+  "sidebar.Docs.category.Getting started": {
+    "message": "Getting started",
+    "description": "The label for category Getting started in sidebar Docs"
+  },
+  "sidebar.Docs.category.Getting started.link.generated-index.title": {
+    "message": "Getting started",
+    "description": "The generated-index page title for category Getting started in sidebar Docs"
+  },
+  "sidebar.Docs.category.Installation": {
+    "message": "Installation",
+    "description": "The label for category Installation in sidebar Docs"
+  },
+  "sidebar.Docs.category.Installation.link.generated-index.title": {
+    "message": "Getting started",
+    "description": "The generated-index page title for category Installation in sidebar Docs"
+  },
+  "sidebar.Docs.category.Management": {
+    "message": "Management",
+    "description": "The label for category Management in sidebar Docs"
+  },
+  "sidebar.Docs.category.Management.link.generated-index.title": {
+    "message": "Management pages",
+    "description": "The generated-index page title for category Management in sidebar Docs"
+  },
+  "sidebar.Docs.category.Integrations": {
+    "message": "Integrations",
+    "description": "The label for category Integrations in sidebar Docs"
+  },
+  "sidebar.Docs.category.Integrations.link.generated-index.title": {
+    "message": "Integrations",
+    "description": "The generated-index page title for category Integrations in sidebar Docs"
+  },
+  "sidebar.Docs.category.Integrations.link.generated-index.description": {
+    "message": "Integration are a principal part of homarr, it's where you can connect your other apps to interact with them with widgets, Homarr currently integrates with the following types of applications:",
+    "description": "The generated-index page description for category Integrations in sidebar Docs"
+  },
+  "sidebar.Docs.category.Widgets": {
+    "message": "Widgets",
+    "description": "The label for category Widgets in sidebar Docs"
+  },
+  "sidebar.Docs.category.Widgets.link.generated-index.title": {
+    "message": "Widgets",
+    "description": "The generated-index page title for category Widgets in sidebar Docs"
+  },
+  "sidebar.Docs.category.Widgets.link.generated-index.description": {
+    "message": "Widgets allow you to show data on your board or control applications. Click on one of the widgets below for further information:",
+    "description": "The generated-index page description for category Widgets in sidebar Docs"
+  },
+  "sidebar.Docs.category.Advanced": {
+    "message": "Advanced",
+    "description": "The label for category Advanced in sidebar Docs"
+  },
+  "sidebar.Docs.category.Advanced.link.generated-index.title": {
+    "message": "Advanced Concepts or features",
+    "description": "The generated-index page title for category Advanced in sidebar Docs"
+  },
+  "sidebar.Docs.category.Developer guides": {
+    "message": "Developer guides",
+    "description": "The label for category Developer guides in sidebar Docs"
+  },
+  "sidebar.Docs.category.Command line interface": {
+    "message": "Command line interface",
+    "description": "The label for category Command line interface in sidebar Docs"
+  },
+  "sidebar.Docs.category.Community": {
+    "message": "Community",
+    "description": "The label for category Community in sidebar Docs"
+  }
+}

--- a/i18n/cn/docusaurus-plugin-content-docs/version-1.11.0.json
+++ b/i18n/cn/docusaurus-plugin-content-docs/version-1.11.0.json
@@ -1,0 +1,82 @@
+{
+  "version.label": {
+    "message": "1.11.0",
+    "description": "The label for version 1.11.0"
+  },
+  "sidebar.GettingStarted.category.Installation": {
+    "message": "Installation",
+    "description": "The label for category Installation in sidebar GettingStarted"
+  },
+  "sidebar.GettingStarted.category.Installation.link.generated-index.title": {
+    "message": "Getting started",
+    "description": "The generated-index page title for category Installation in sidebar GettingStarted"
+  },
+  "sidebar.Docs.category.Getting started": {
+    "message": "Getting started",
+    "description": "The label for category Getting started in sidebar Docs"
+  },
+  "sidebar.Docs.category.Getting started.link.generated-index.title": {
+    "message": "Getting started",
+    "description": "The generated-index page title for category Getting started in sidebar Docs"
+  },
+  "sidebar.Docs.category.Installation": {
+    "message": "Installation",
+    "description": "The label for category Installation in sidebar Docs"
+  },
+  "sidebar.Docs.category.Installation.link.generated-index.title": {
+    "message": "Getting started",
+    "description": "The generated-index page title for category Installation in sidebar Docs"
+  },
+  "sidebar.Docs.category.Management": {
+    "message": "Management",
+    "description": "The label for category Management in sidebar Docs"
+  },
+  "sidebar.Docs.category.Management.link.generated-index.title": {
+    "message": "Management pages",
+    "description": "The generated-index page title for category Management in sidebar Docs"
+  },
+  "sidebar.Docs.category.Integrations": {
+    "message": "Integrations",
+    "description": "The label for category Integrations in sidebar Docs"
+  },
+  "sidebar.Docs.category.Integrations.link.generated-index.title": {
+    "message": "Integrations",
+    "description": "The generated-index page title for category Integrations in sidebar Docs"
+  },
+  "sidebar.Docs.category.Integrations.link.generated-index.description": {
+    "message": "Integration are a principal part of homarr, it's where you can connect your other apps to interact with them with widgets, Homarr currently integrates with the following types of applications:",
+    "description": "The generated-index page description for category Integrations in sidebar Docs"
+  },
+  "sidebar.Docs.category.Widgets": {
+    "message": "Widgets",
+    "description": "The label for category Widgets in sidebar Docs"
+  },
+  "sidebar.Docs.category.Widgets.link.generated-index.title": {
+    "message": "Widgets",
+    "description": "The generated-index page title for category Widgets in sidebar Docs"
+  },
+  "sidebar.Docs.category.Widgets.link.generated-index.description": {
+    "message": "Widgets allow you to show data on your board or control applications. Click on one of the widgets below for further information:",
+    "description": "The generated-index page description for category Widgets in sidebar Docs"
+  },
+  "sidebar.Docs.category.Advanced": {
+    "message": "Advanced",
+    "description": "The label for category Advanced in sidebar Docs"
+  },
+  "sidebar.Docs.category.Advanced.link.generated-index.title": {
+    "message": "Advanced Concepts or features",
+    "description": "The generated-index page title for category Advanced in sidebar Docs"
+  },
+  "sidebar.Docs.category.Developer guides": {
+    "message": "Developer guides",
+    "description": "The label for category Developer guides in sidebar Docs"
+  },
+  "sidebar.Docs.category.Command line interface": {
+    "message": "Command line interface",
+    "description": "The label for category Command line interface in sidebar Docs"
+  },
+  "sidebar.Docs.category.Community": {
+    "message": "Community",
+    "description": "The label for category Community in sidebar Docs"
+  }
+}

--- a/i18n/cn/docusaurus-plugin-content-docs/version-1.12.0.json
+++ b/i18n/cn/docusaurus-plugin-content-docs/version-1.12.0.json
@@ -1,0 +1,82 @@
+{
+  "version.label": {
+    "message": "1.12.0",
+    "description": "The label for version 1.12.0"
+  },
+  "sidebar.GettingStarted.category.Installation": {
+    "message": "Installation",
+    "description": "The label for category Installation in sidebar GettingStarted"
+  },
+  "sidebar.GettingStarted.category.Installation.link.generated-index.title": {
+    "message": "Getting started",
+    "description": "The generated-index page title for category Installation in sidebar GettingStarted"
+  },
+  "sidebar.Docs.category.Getting started": {
+    "message": "Getting started",
+    "description": "The label for category Getting started in sidebar Docs"
+  },
+  "sidebar.Docs.category.Getting started.link.generated-index.title": {
+    "message": "Getting started",
+    "description": "The generated-index page title for category Getting started in sidebar Docs"
+  },
+  "sidebar.Docs.category.Installation": {
+    "message": "Installation",
+    "description": "The label for category Installation in sidebar Docs"
+  },
+  "sidebar.Docs.category.Installation.link.generated-index.title": {
+    "message": "Getting started",
+    "description": "The generated-index page title for category Installation in sidebar Docs"
+  },
+  "sidebar.Docs.category.Management": {
+    "message": "Management",
+    "description": "The label for category Management in sidebar Docs"
+  },
+  "sidebar.Docs.category.Management.link.generated-index.title": {
+    "message": "Management pages",
+    "description": "The generated-index page title for category Management in sidebar Docs"
+  },
+  "sidebar.Docs.category.Integrations": {
+    "message": "Integrations",
+    "description": "The label for category Integrations in sidebar Docs"
+  },
+  "sidebar.Docs.category.Integrations.link.generated-index.title": {
+    "message": "Integrations",
+    "description": "The generated-index page title for category Integrations in sidebar Docs"
+  },
+  "sidebar.Docs.category.Integrations.link.generated-index.description": {
+    "message": "Integration are a principal part of homarr, it's where you can connect your other apps to interact with them with widgets, Homarr currently integrates with the following types of applications:",
+    "description": "The generated-index page description for category Integrations in sidebar Docs"
+  },
+  "sidebar.Docs.category.Widgets": {
+    "message": "Widgets",
+    "description": "The label for category Widgets in sidebar Docs"
+  },
+  "sidebar.Docs.category.Widgets.link.generated-index.title": {
+    "message": "Widgets",
+    "description": "The generated-index page title for category Widgets in sidebar Docs"
+  },
+  "sidebar.Docs.category.Widgets.link.generated-index.description": {
+    "message": "Widgets allow you to show data on your board or control applications. Click on one of the widgets below for further information:",
+    "description": "The generated-index page description for category Widgets in sidebar Docs"
+  },
+  "sidebar.Docs.category.Advanced": {
+    "message": "Advanced",
+    "description": "The label for category Advanced in sidebar Docs"
+  },
+  "sidebar.Docs.category.Advanced.link.generated-index.title": {
+    "message": "Advanced Concepts or features",
+    "description": "The generated-index page title for category Advanced in sidebar Docs"
+  },
+  "sidebar.Docs.category.Developer guides": {
+    "message": "Developer guides",
+    "description": "The label for category Developer guides in sidebar Docs"
+  },
+  "sidebar.Docs.category.Command line interface": {
+    "message": "Command line interface",
+    "description": "The label for category Command line interface in sidebar Docs"
+  },
+  "sidebar.Docs.category.Community": {
+    "message": "Community",
+    "description": "The label for category Community in sidebar Docs"
+  }
+}

--- a/i18n/cn/docusaurus-plugin-content-docs/version-1.13.1.json
+++ b/i18n/cn/docusaurus-plugin-content-docs/version-1.13.1.json
@@ -1,0 +1,82 @@
+{
+  "version.label": {
+    "message": "1.13.1",
+    "description": "The label for version 1.13.1"
+  },
+  "sidebar.GettingStarted.category.Installation": {
+    "message": "Installation",
+    "description": "The label for category Installation in sidebar GettingStarted"
+  },
+  "sidebar.GettingStarted.category.Installation.link.generated-index.title": {
+    "message": "Getting started",
+    "description": "The generated-index page title for category Installation in sidebar GettingStarted"
+  },
+  "sidebar.Docs.category.Getting started": {
+    "message": "Getting started",
+    "description": "The label for category Getting started in sidebar Docs"
+  },
+  "sidebar.Docs.category.Getting started.link.generated-index.title": {
+    "message": "Getting started",
+    "description": "The generated-index page title for category Getting started in sidebar Docs"
+  },
+  "sidebar.Docs.category.Installation": {
+    "message": "Installation",
+    "description": "The label for category Installation in sidebar Docs"
+  },
+  "sidebar.Docs.category.Installation.link.generated-index.title": {
+    "message": "Getting started",
+    "description": "The generated-index page title for category Installation in sidebar Docs"
+  },
+  "sidebar.Docs.category.Management": {
+    "message": "Management",
+    "description": "The label for category Management in sidebar Docs"
+  },
+  "sidebar.Docs.category.Management.link.generated-index.title": {
+    "message": "Management pages",
+    "description": "The generated-index page title for category Management in sidebar Docs"
+  },
+  "sidebar.Docs.category.Integrations": {
+    "message": "Integrations",
+    "description": "The label for category Integrations in sidebar Docs"
+  },
+  "sidebar.Docs.category.Integrations.link.generated-index.title": {
+    "message": "Integrations",
+    "description": "The generated-index page title for category Integrations in sidebar Docs"
+  },
+  "sidebar.Docs.category.Integrations.link.generated-index.description": {
+    "message": "Integration are a principal part of homarr, it's where you can connect your other apps to interact with them with widgets, Homarr currently integrates with the following types of applications:",
+    "description": "The generated-index page description for category Integrations in sidebar Docs"
+  },
+  "sidebar.Docs.category.Widgets": {
+    "message": "Widgets",
+    "description": "The label for category Widgets in sidebar Docs"
+  },
+  "sidebar.Docs.category.Widgets.link.generated-index.title": {
+    "message": "Widgets",
+    "description": "The generated-index page title for category Widgets in sidebar Docs"
+  },
+  "sidebar.Docs.category.Widgets.link.generated-index.description": {
+    "message": "Widgets allow you to show data on your board or control applications. Click on one of the widgets below for further information:",
+    "description": "The generated-index page description for category Widgets in sidebar Docs"
+  },
+  "sidebar.Docs.category.Advanced": {
+    "message": "Advanced",
+    "description": "The label for category Advanced in sidebar Docs"
+  },
+  "sidebar.Docs.category.Advanced.link.generated-index.title": {
+    "message": "Advanced Concepts or features",
+    "description": "The generated-index page title for category Advanced in sidebar Docs"
+  },
+  "sidebar.Docs.category.Developer guides": {
+    "message": "Developer guides",
+    "description": "The label for category Developer guides in sidebar Docs"
+  },
+  "sidebar.Docs.category.Command line interface": {
+    "message": "Command line interface",
+    "description": "The label for category Command line interface in sidebar Docs"
+  },
+  "sidebar.Docs.category.Community": {
+    "message": "Community",
+    "description": "The label for category Community in sidebar Docs"
+  }
+}

--- a/i18n/cn/docusaurus-plugin-content-docs/version-1.14.0.json
+++ b/i18n/cn/docusaurus-plugin-content-docs/version-1.14.0.json
@@ -1,0 +1,82 @@
+{
+  "version.label": {
+    "message": "1.14.0",
+    "description": "The label for version 1.14.0"
+  },
+  "sidebar.GettingStarted.category.Installation": {
+    "message": "Installation",
+    "description": "The label for category Installation in sidebar GettingStarted"
+  },
+  "sidebar.GettingStarted.category.Installation.link.generated-index.title": {
+    "message": "Getting started",
+    "description": "The generated-index page title for category Installation in sidebar GettingStarted"
+  },
+  "sidebar.Docs.category.Getting started": {
+    "message": "Getting started",
+    "description": "The label for category Getting started in sidebar Docs"
+  },
+  "sidebar.Docs.category.Getting started.link.generated-index.title": {
+    "message": "Getting started",
+    "description": "The generated-index page title for category Getting started in sidebar Docs"
+  },
+  "sidebar.Docs.category.Installation": {
+    "message": "Installation",
+    "description": "The label for category Installation in sidebar Docs"
+  },
+  "sidebar.Docs.category.Installation.link.generated-index.title": {
+    "message": "Getting started",
+    "description": "The generated-index page title for category Installation in sidebar Docs"
+  },
+  "sidebar.Docs.category.Management": {
+    "message": "Management",
+    "description": "The label for category Management in sidebar Docs"
+  },
+  "sidebar.Docs.category.Management.link.generated-index.title": {
+    "message": "Management pages",
+    "description": "The generated-index page title for category Management in sidebar Docs"
+  },
+  "sidebar.Docs.category.Integrations": {
+    "message": "Integrations",
+    "description": "The label for category Integrations in sidebar Docs"
+  },
+  "sidebar.Docs.category.Integrations.link.generated-index.title": {
+    "message": "Integrations",
+    "description": "The generated-index page title for category Integrations in sidebar Docs"
+  },
+  "sidebar.Docs.category.Integrations.link.generated-index.description": {
+    "message": "Integration are a principal part of homarr, it's where you can connect your other apps to interact with them with widgets, Homarr currently integrates with the following types of applications:",
+    "description": "The generated-index page description for category Integrations in sidebar Docs"
+  },
+  "sidebar.Docs.category.Widgets": {
+    "message": "Widgets",
+    "description": "The label for category Widgets in sidebar Docs"
+  },
+  "sidebar.Docs.category.Widgets.link.generated-index.title": {
+    "message": "Widgets",
+    "description": "The generated-index page title for category Widgets in sidebar Docs"
+  },
+  "sidebar.Docs.category.Widgets.link.generated-index.description": {
+    "message": "Widgets allow you to show data on your board or control applications. Click on one of the widgets below for further information:",
+    "description": "The generated-index page description for category Widgets in sidebar Docs"
+  },
+  "sidebar.Docs.category.Advanced": {
+    "message": "Advanced",
+    "description": "The label for category Advanced in sidebar Docs"
+  },
+  "sidebar.Docs.category.Advanced.link.generated-index.title": {
+    "message": "Advanced Concepts or features",
+    "description": "The generated-index page title for category Advanced in sidebar Docs"
+  },
+  "sidebar.Docs.category.Developer guides": {
+    "message": "Developer guides",
+    "description": "The label for category Developer guides in sidebar Docs"
+  },
+  "sidebar.Docs.category.Command line interface": {
+    "message": "Command line interface",
+    "description": "The label for category Command line interface in sidebar Docs"
+  },
+  "sidebar.Docs.category.Community": {
+    "message": "Community",
+    "description": "The label for category Community in sidebar Docs"
+  }
+}

--- a/i18n/cn/docusaurus-plugin-content-docs/version-1.15.0.json
+++ b/i18n/cn/docusaurus-plugin-content-docs/version-1.15.0.json
@@ -1,0 +1,82 @@
+{
+  "version.label": {
+    "message": "1.15.0",
+    "description": "The label for version 1.15.0"
+  },
+  "sidebar.GettingStarted.category.Installation": {
+    "message": "Installation",
+    "description": "The label for category Installation in sidebar GettingStarted"
+  },
+  "sidebar.GettingStarted.category.Installation.link.generated-index.title": {
+    "message": "Getting started",
+    "description": "The generated-index page title for category Installation in sidebar GettingStarted"
+  },
+  "sidebar.Docs.category.Getting started": {
+    "message": "Getting started",
+    "description": "The label for category Getting started in sidebar Docs"
+  },
+  "sidebar.Docs.category.Getting started.link.generated-index.title": {
+    "message": "Getting started",
+    "description": "The generated-index page title for category Getting started in sidebar Docs"
+  },
+  "sidebar.Docs.category.Installation": {
+    "message": "Installation",
+    "description": "The label for category Installation in sidebar Docs"
+  },
+  "sidebar.Docs.category.Installation.link.generated-index.title": {
+    "message": "Getting started",
+    "description": "The generated-index page title for category Installation in sidebar Docs"
+  },
+  "sidebar.Docs.category.Management": {
+    "message": "Management",
+    "description": "The label for category Management in sidebar Docs"
+  },
+  "sidebar.Docs.category.Management.link.generated-index.title": {
+    "message": "Management pages",
+    "description": "The generated-index page title for category Management in sidebar Docs"
+  },
+  "sidebar.Docs.category.Integrations": {
+    "message": "Integrations",
+    "description": "The label for category Integrations in sidebar Docs"
+  },
+  "sidebar.Docs.category.Integrations.link.generated-index.title": {
+    "message": "Integrations",
+    "description": "The generated-index page title for category Integrations in sidebar Docs"
+  },
+  "sidebar.Docs.category.Integrations.link.generated-index.description": {
+    "message": "Integration are a principal part of homarr, it's where you can connect your other apps to interact with them with widgets, Homarr currently integrates with the following types of applications:",
+    "description": "The generated-index page description for category Integrations in sidebar Docs"
+  },
+  "sidebar.Docs.category.Widgets": {
+    "message": "Widgets",
+    "description": "The label for category Widgets in sidebar Docs"
+  },
+  "sidebar.Docs.category.Widgets.link.generated-index.title": {
+    "message": "Widgets",
+    "description": "The generated-index page title for category Widgets in sidebar Docs"
+  },
+  "sidebar.Docs.category.Widgets.link.generated-index.description": {
+    "message": "Widgets allow you to show data on your board or control applications. Click on one of the widgets below for further information:",
+    "description": "The generated-index page description for category Widgets in sidebar Docs"
+  },
+  "sidebar.Docs.category.Advanced": {
+    "message": "Advanced",
+    "description": "The label for category Advanced in sidebar Docs"
+  },
+  "sidebar.Docs.category.Advanced.link.generated-index.title": {
+    "message": "Advanced Concepts or features",
+    "description": "The generated-index page title for category Advanced in sidebar Docs"
+  },
+  "sidebar.Docs.category.Developer guides": {
+    "message": "Developer guides",
+    "description": "The label for category Developer guides in sidebar Docs"
+  },
+  "sidebar.Docs.category.Command line interface": {
+    "message": "Command line interface",
+    "description": "The label for category Command line interface in sidebar Docs"
+  },
+  "sidebar.Docs.category.Community": {
+    "message": "Community",
+    "description": "The label for category Community in sidebar Docs"
+  }
+}

--- a/i18n/cn/docusaurus-plugin-content-docs/version-1.18.0.json
+++ b/i18n/cn/docusaurus-plugin-content-docs/version-1.18.0.json
@@ -1,0 +1,82 @@
+{
+  "version.label": {
+    "message": "1.18.0",
+    "description": "The label for version 1.18.0"
+  },
+  "sidebar.GettingStarted.category.Installation": {
+    "message": "Installation",
+    "description": "The label for category Installation in sidebar GettingStarted"
+  },
+  "sidebar.GettingStarted.category.Installation.link.generated-index.title": {
+    "message": "Getting started",
+    "description": "The generated-index page title for category Installation in sidebar GettingStarted"
+  },
+  "sidebar.Docs.category.Getting started": {
+    "message": "Getting started",
+    "description": "The label for category Getting started in sidebar Docs"
+  },
+  "sidebar.Docs.category.Getting started.link.generated-index.title": {
+    "message": "Getting started",
+    "description": "The generated-index page title for category Getting started in sidebar Docs"
+  },
+  "sidebar.Docs.category.Installation": {
+    "message": "Installation",
+    "description": "The label for category Installation in sidebar Docs"
+  },
+  "sidebar.Docs.category.Installation.link.generated-index.title": {
+    "message": "Getting started",
+    "description": "The generated-index page title for category Installation in sidebar Docs"
+  },
+  "sidebar.Docs.category.Management": {
+    "message": "Management",
+    "description": "The label for category Management in sidebar Docs"
+  },
+  "sidebar.Docs.category.Management.link.generated-index.title": {
+    "message": "Management pages",
+    "description": "The generated-index page title for category Management in sidebar Docs"
+  },
+  "sidebar.Docs.category.Integrations": {
+    "message": "Integrations",
+    "description": "The label for category Integrations in sidebar Docs"
+  },
+  "sidebar.Docs.category.Integrations.link.generated-index.title": {
+    "message": "Integrations",
+    "description": "The generated-index page title for category Integrations in sidebar Docs"
+  },
+  "sidebar.Docs.category.Integrations.link.generated-index.description": {
+    "message": "Integration are a principal part of homarr, it's where you can connect your other apps to interact with them with widgets, Homarr currently integrates with the following types of applications:",
+    "description": "The generated-index page description for category Integrations in sidebar Docs"
+  },
+  "sidebar.Docs.category.Widgets": {
+    "message": "Widgets",
+    "description": "The label for category Widgets in sidebar Docs"
+  },
+  "sidebar.Docs.category.Widgets.link.generated-index.title": {
+    "message": "Widgets",
+    "description": "The generated-index page title for category Widgets in sidebar Docs"
+  },
+  "sidebar.Docs.category.Widgets.link.generated-index.description": {
+    "message": "Widgets allow you to show data on your board or control applications. Click on one of the widgets below for further information:",
+    "description": "The generated-index page description for category Widgets in sidebar Docs"
+  },
+  "sidebar.Docs.category.Advanced": {
+    "message": "Advanced",
+    "description": "The label for category Advanced in sidebar Docs"
+  },
+  "sidebar.Docs.category.Advanced.link.generated-index.title": {
+    "message": "Advanced Concepts or features",
+    "description": "The generated-index page title for category Advanced in sidebar Docs"
+  },
+  "sidebar.Docs.category.Developer guides": {
+    "message": "Developer guides",
+    "description": "The label for category Developer guides in sidebar Docs"
+  },
+  "sidebar.Docs.category.Command line interface": {
+    "message": "Command line interface",
+    "description": "The label for category Command line interface in sidebar Docs"
+  },
+  "sidebar.Docs.category.Community": {
+    "message": "Community",
+    "description": "The label for category Community in sidebar Docs"
+  }
+}

--- a/i18n/cn/docusaurus-plugin-content-docs/version-1.19.0.json
+++ b/i18n/cn/docusaurus-plugin-content-docs/version-1.19.0.json
@@ -1,0 +1,82 @@
+{
+  "version.label": {
+    "message": "1.19.0",
+    "description": "The label for version 1.19.0"
+  },
+  "sidebar.GettingStarted.category.Installation": {
+    "message": "Installation",
+    "description": "The label for category Installation in sidebar GettingStarted"
+  },
+  "sidebar.GettingStarted.category.Installation.link.generated-index.title": {
+    "message": "Getting started",
+    "description": "The generated-index page title for category Installation in sidebar GettingStarted"
+  },
+  "sidebar.Docs.category.Getting started": {
+    "message": "Getting started",
+    "description": "The label for category Getting started in sidebar Docs"
+  },
+  "sidebar.Docs.category.Getting started.link.generated-index.title": {
+    "message": "Getting started",
+    "description": "The generated-index page title for category Getting started in sidebar Docs"
+  },
+  "sidebar.Docs.category.Installation": {
+    "message": "Installation",
+    "description": "The label for category Installation in sidebar Docs"
+  },
+  "sidebar.Docs.category.Installation.link.generated-index.title": {
+    "message": "Getting started",
+    "description": "The generated-index page title for category Installation in sidebar Docs"
+  },
+  "sidebar.Docs.category.Management": {
+    "message": "Management",
+    "description": "The label for category Management in sidebar Docs"
+  },
+  "sidebar.Docs.category.Management.link.generated-index.title": {
+    "message": "Management pages",
+    "description": "The generated-index page title for category Management in sidebar Docs"
+  },
+  "sidebar.Docs.category.Integrations": {
+    "message": "Integrations",
+    "description": "The label for category Integrations in sidebar Docs"
+  },
+  "sidebar.Docs.category.Integrations.link.generated-index.title": {
+    "message": "Integrations",
+    "description": "The generated-index page title for category Integrations in sidebar Docs"
+  },
+  "sidebar.Docs.category.Integrations.link.generated-index.description": {
+    "message": "Integration are a principal part of homarr, it's where you can connect your other apps to interact with them with widgets, Homarr currently integrates with the following types of applications:",
+    "description": "The generated-index page description for category Integrations in sidebar Docs"
+  },
+  "sidebar.Docs.category.Widgets": {
+    "message": "Widgets",
+    "description": "The label for category Widgets in sidebar Docs"
+  },
+  "sidebar.Docs.category.Widgets.link.generated-index.title": {
+    "message": "Widgets",
+    "description": "The generated-index page title for category Widgets in sidebar Docs"
+  },
+  "sidebar.Docs.category.Widgets.link.generated-index.description": {
+    "message": "Widgets allow you to show data on your board or control applications. Click on one of the widgets below for further information:",
+    "description": "The generated-index page description for category Widgets in sidebar Docs"
+  },
+  "sidebar.Docs.category.Advanced": {
+    "message": "Advanced",
+    "description": "The label for category Advanced in sidebar Docs"
+  },
+  "sidebar.Docs.category.Advanced.link.generated-index.title": {
+    "message": "Advanced Concepts or features",
+    "description": "The generated-index page title for category Advanced in sidebar Docs"
+  },
+  "sidebar.Docs.category.Developer guides": {
+    "message": "Developer guides",
+    "description": "The label for category Developer guides in sidebar Docs"
+  },
+  "sidebar.Docs.category.Command line interface": {
+    "message": "Command line interface",
+    "description": "The label for category Command line interface in sidebar Docs"
+  },
+  "sidebar.Docs.category.Community": {
+    "message": "Community",
+    "description": "The label for category Community in sidebar Docs"
+  }
+}

--- a/i18n/cn/docusaurus-plugin-content-docs/version-1.21.0.json
+++ b/i18n/cn/docusaurus-plugin-content-docs/version-1.21.0.json
@@ -1,0 +1,82 @@
+{
+  "version.label": {
+    "message": "1.21.0",
+    "description": "The label for version 1.21.0"
+  },
+  "sidebar.GettingStarted.category.Installation": {
+    "message": "Installation",
+    "description": "The label for category Installation in sidebar GettingStarted"
+  },
+  "sidebar.GettingStarted.category.Installation.link.generated-index.title": {
+    "message": "Getting started",
+    "description": "The generated-index page title for category Installation in sidebar GettingStarted"
+  },
+  "sidebar.Docs.category.Getting started": {
+    "message": "Getting started",
+    "description": "The label for category Getting started in sidebar Docs"
+  },
+  "sidebar.Docs.category.Getting started.link.generated-index.title": {
+    "message": "Getting started",
+    "description": "The generated-index page title for category Getting started in sidebar Docs"
+  },
+  "sidebar.Docs.category.Installation": {
+    "message": "Installation",
+    "description": "The label for category Installation in sidebar Docs"
+  },
+  "sidebar.Docs.category.Installation.link.generated-index.title": {
+    "message": "Getting started",
+    "description": "The generated-index page title for category Installation in sidebar Docs"
+  },
+  "sidebar.Docs.category.Management": {
+    "message": "Management",
+    "description": "The label for category Management in sidebar Docs"
+  },
+  "sidebar.Docs.category.Management.link.generated-index.title": {
+    "message": "Management pages",
+    "description": "The generated-index page title for category Management in sidebar Docs"
+  },
+  "sidebar.Docs.category.Integrations": {
+    "message": "Integrations",
+    "description": "The label for category Integrations in sidebar Docs"
+  },
+  "sidebar.Docs.category.Integrations.link.generated-index.title": {
+    "message": "Integrations",
+    "description": "The generated-index page title for category Integrations in sidebar Docs"
+  },
+  "sidebar.Docs.category.Integrations.link.generated-index.description": {
+    "message": "Integration are a principal part of homarr, it's where you can connect your other apps to interact with them with widgets, Homarr currently integrates with the following types of applications:",
+    "description": "The generated-index page description for category Integrations in sidebar Docs"
+  },
+  "sidebar.Docs.category.Widgets": {
+    "message": "Widgets",
+    "description": "The label for category Widgets in sidebar Docs"
+  },
+  "sidebar.Docs.category.Widgets.link.generated-index.title": {
+    "message": "Widgets",
+    "description": "The generated-index page title for category Widgets in sidebar Docs"
+  },
+  "sidebar.Docs.category.Widgets.link.generated-index.description": {
+    "message": "Widgets allow you to show data on your board or control applications. Click on one of the widgets below for further information:",
+    "description": "The generated-index page description for category Widgets in sidebar Docs"
+  },
+  "sidebar.Docs.category.Advanced": {
+    "message": "Advanced",
+    "description": "The label for category Advanced in sidebar Docs"
+  },
+  "sidebar.Docs.category.Advanced.link.generated-index.title": {
+    "message": "Advanced Concepts or features",
+    "description": "The generated-index page title for category Advanced in sidebar Docs"
+  },
+  "sidebar.Docs.category.Developer guides": {
+    "message": "Developer guides",
+    "description": "The label for category Developer guides in sidebar Docs"
+  },
+  "sidebar.Docs.category.Command line interface": {
+    "message": "Command line interface",
+    "description": "The label for category Command line interface in sidebar Docs"
+  },
+  "sidebar.Docs.category.Community": {
+    "message": "Community",
+    "description": "The label for category Community in sidebar Docs"
+  }
+}

--- a/i18n/cn/docusaurus-plugin-content-docs/version-1.27.0.json
+++ b/i18n/cn/docusaurus-plugin-content-docs/version-1.27.0.json
@@ -1,0 +1,82 @@
+{
+  "version.label": {
+    "message": "1.27.0",
+    "description": "The label for version 1.27.0"
+  },
+  "sidebar.GettingStarted.category.Installation": {
+    "message": "Installation",
+    "description": "The label for category Installation in sidebar GettingStarted"
+  },
+  "sidebar.GettingStarted.category.Installation.link.generated-index.title": {
+    "message": "Getting started",
+    "description": "The generated-index page title for category Installation in sidebar GettingStarted"
+  },
+  "sidebar.Docs.category.Getting started": {
+    "message": "Getting started",
+    "description": "The label for category Getting started in sidebar Docs"
+  },
+  "sidebar.Docs.category.Getting started.link.generated-index.title": {
+    "message": "Getting started",
+    "description": "The generated-index page title for category Getting started in sidebar Docs"
+  },
+  "sidebar.Docs.category.Installation": {
+    "message": "Installation",
+    "description": "The label for category Installation in sidebar Docs"
+  },
+  "sidebar.Docs.category.Installation.link.generated-index.title": {
+    "message": "Getting started",
+    "description": "The generated-index page title for category Installation in sidebar Docs"
+  },
+  "sidebar.Docs.category.Management": {
+    "message": "Management",
+    "description": "The label for category Management in sidebar Docs"
+  },
+  "sidebar.Docs.category.Management.link.generated-index.title": {
+    "message": "Management pages",
+    "description": "The generated-index page title for category Management in sidebar Docs"
+  },
+  "sidebar.Docs.category.Integrations": {
+    "message": "Integrations",
+    "description": "The label for category Integrations in sidebar Docs"
+  },
+  "sidebar.Docs.category.Integrations.link.generated-index.title": {
+    "message": "Integrations",
+    "description": "The generated-index page title for category Integrations in sidebar Docs"
+  },
+  "sidebar.Docs.category.Integrations.link.generated-index.description": {
+    "message": "Integration are a principal part of homarr, it's where you can connect your other apps to interact with them with widgets, Homarr currently integrates with the following types of applications:",
+    "description": "The generated-index page description for category Integrations in sidebar Docs"
+  },
+  "sidebar.Docs.category.Widgets": {
+    "message": "Widgets",
+    "description": "The label for category Widgets in sidebar Docs"
+  },
+  "sidebar.Docs.category.Widgets.link.generated-index.title": {
+    "message": "Widgets",
+    "description": "The generated-index page title for category Widgets in sidebar Docs"
+  },
+  "sidebar.Docs.category.Widgets.link.generated-index.description": {
+    "message": "Widgets allow you to show data on your board or control applications. Click on one of the widgets below for further information:",
+    "description": "The generated-index page description for category Widgets in sidebar Docs"
+  },
+  "sidebar.Docs.category.Advanced": {
+    "message": "Advanced",
+    "description": "The label for category Advanced in sidebar Docs"
+  },
+  "sidebar.Docs.category.Advanced.link.generated-index.title": {
+    "message": "Advanced Concepts or features",
+    "description": "The generated-index page title for category Advanced in sidebar Docs"
+  },
+  "sidebar.Docs.category.Developer guides": {
+    "message": "Developer guides",
+    "description": "The label for category Developer guides in sidebar Docs"
+  },
+  "sidebar.Docs.category.Command line interface": {
+    "message": "Command line interface",
+    "description": "The label for category Command line interface in sidebar Docs"
+  },
+  "sidebar.Docs.category.Community": {
+    "message": "Community",
+    "description": "The label for category Community in sidebar Docs"
+  }
+}

--- a/i18n/cn/docusaurus-plugin-content-docs/version-1.29.0.json
+++ b/i18n/cn/docusaurus-plugin-content-docs/version-1.29.0.json
@@ -1,0 +1,82 @@
+{
+  "version.label": {
+    "message": "1.29.0",
+    "description": "The label for version 1.29.0"
+  },
+  "sidebar.GettingStarted.category.Installation": {
+    "message": "Installation",
+    "description": "The label for category Installation in sidebar GettingStarted"
+  },
+  "sidebar.GettingStarted.category.Installation.link.generated-index.title": {
+    "message": "Getting started",
+    "description": "The generated-index page title for category Installation in sidebar GettingStarted"
+  },
+  "sidebar.Docs.category.Getting started": {
+    "message": "Getting started",
+    "description": "The label for category Getting started in sidebar Docs"
+  },
+  "sidebar.Docs.category.Getting started.link.generated-index.title": {
+    "message": "Getting started",
+    "description": "The generated-index page title for category Getting started in sidebar Docs"
+  },
+  "sidebar.Docs.category.Installation": {
+    "message": "Installation",
+    "description": "The label for category Installation in sidebar Docs"
+  },
+  "sidebar.Docs.category.Installation.link.generated-index.title": {
+    "message": "Getting started",
+    "description": "The generated-index page title for category Installation in sidebar Docs"
+  },
+  "sidebar.Docs.category.Management": {
+    "message": "Management",
+    "description": "The label for category Management in sidebar Docs"
+  },
+  "sidebar.Docs.category.Management.link.generated-index.title": {
+    "message": "Management pages",
+    "description": "The generated-index page title for category Management in sidebar Docs"
+  },
+  "sidebar.Docs.category.Integrations": {
+    "message": "Integrations",
+    "description": "The label for category Integrations in sidebar Docs"
+  },
+  "sidebar.Docs.category.Integrations.link.generated-index.title": {
+    "message": "Integrations",
+    "description": "The generated-index page title for category Integrations in sidebar Docs"
+  },
+  "sidebar.Docs.category.Integrations.link.generated-index.description": {
+    "message": "Integration are a principal part of homarr, it's where you can connect your other apps to interact with them with widgets, Homarr currently integrates with the following types of applications:",
+    "description": "The generated-index page description for category Integrations in sidebar Docs"
+  },
+  "sidebar.Docs.category.Widgets": {
+    "message": "Widgets",
+    "description": "The label for category Widgets in sidebar Docs"
+  },
+  "sidebar.Docs.category.Widgets.link.generated-index.title": {
+    "message": "Widgets",
+    "description": "The generated-index page title for category Widgets in sidebar Docs"
+  },
+  "sidebar.Docs.category.Widgets.link.generated-index.description": {
+    "message": "Widgets allow you to show data on your board or control applications. Click on one of the widgets below for further information:",
+    "description": "The generated-index page description for category Widgets in sidebar Docs"
+  },
+  "sidebar.Docs.category.Advanced": {
+    "message": "Advanced",
+    "description": "The label for category Advanced in sidebar Docs"
+  },
+  "sidebar.Docs.category.Advanced.link.generated-index.title": {
+    "message": "Advanced Concepts or features",
+    "description": "The generated-index page title for category Advanced in sidebar Docs"
+  },
+  "sidebar.Docs.category.Developer guides": {
+    "message": "Developer guides",
+    "description": "The label for category Developer guides in sidebar Docs"
+  },
+  "sidebar.Docs.category.Command line interface": {
+    "message": "Command line interface",
+    "description": "The label for category Command line interface in sidebar Docs"
+  },
+  "sidebar.Docs.category.Community": {
+    "message": "Community",
+    "description": "The label for category Community in sidebar Docs"
+  }
+}

--- a/i18n/cn/docusaurus-plugin-content-docs/version-1.30.0.json
+++ b/i18n/cn/docusaurus-plugin-content-docs/version-1.30.0.json
@@ -1,0 +1,82 @@
+{
+  "version.label": {
+    "message": "1.30.0",
+    "description": "The label for version 1.30.0"
+  },
+  "sidebar.GettingStarted.category.Installation": {
+    "message": "Installation",
+    "description": "The label for category Installation in sidebar GettingStarted"
+  },
+  "sidebar.GettingStarted.category.Installation.link.generated-index.title": {
+    "message": "Getting started",
+    "description": "The generated-index page title for category Installation in sidebar GettingStarted"
+  },
+  "sidebar.Docs.category.Getting started": {
+    "message": "Getting started",
+    "description": "The label for category Getting started in sidebar Docs"
+  },
+  "sidebar.Docs.category.Getting started.link.generated-index.title": {
+    "message": "Getting started",
+    "description": "The generated-index page title for category Getting started in sidebar Docs"
+  },
+  "sidebar.Docs.category.Installation": {
+    "message": "Installation",
+    "description": "The label for category Installation in sidebar Docs"
+  },
+  "sidebar.Docs.category.Installation.link.generated-index.title": {
+    "message": "Getting started",
+    "description": "The generated-index page title for category Installation in sidebar Docs"
+  },
+  "sidebar.Docs.category.Management": {
+    "message": "Management",
+    "description": "The label for category Management in sidebar Docs"
+  },
+  "sidebar.Docs.category.Management.link.generated-index.title": {
+    "message": "Management pages",
+    "description": "The generated-index page title for category Management in sidebar Docs"
+  },
+  "sidebar.Docs.category.Integrations": {
+    "message": "Integrations",
+    "description": "The label for category Integrations in sidebar Docs"
+  },
+  "sidebar.Docs.category.Integrations.link.generated-index.title": {
+    "message": "Integrations",
+    "description": "The generated-index page title for category Integrations in sidebar Docs"
+  },
+  "sidebar.Docs.category.Integrations.link.generated-index.description": {
+    "message": "Integration are a principal part of homarr, it's where you can connect your other apps to interact with them with widgets or other capabilities, Homarr currently integrates with the following applications:",
+    "description": "The generated-index page description for category Integrations in sidebar Docs"
+  },
+  "sidebar.Docs.category.Widgets": {
+    "message": "Widgets",
+    "description": "The label for category Widgets in sidebar Docs"
+  },
+  "sidebar.Docs.category.Widgets.link.generated-index.title": {
+    "message": "Widgets",
+    "description": "The generated-index page title for category Widgets in sidebar Docs"
+  },
+  "sidebar.Docs.category.Widgets.link.generated-index.description": {
+    "message": "Widgets allow you to show data on your board or control applications. Click on one of the widgets below for further information:",
+    "description": "The generated-index page description for category Widgets in sidebar Docs"
+  },
+  "sidebar.Docs.category.Advanced": {
+    "message": "Advanced",
+    "description": "The label for category Advanced in sidebar Docs"
+  },
+  "sidebar.Docs.category.Advanced.link.generated-index.title": {
+    "message": "Advanced Concepts or features",
+    "description": "The generated-index page title for category Advanced in sidebar Docs"
+  },
+  "sidebar.Docs.category.Developer guides": {
+    "message": "Developer guides",
+    "description": "The label for category Developer guides in sidebar Docs"
+  },
+  "sidebar.Docs.category.Command line interface": {
+    "message": "Command line interface",
+    "description": "The label for category Command line interface in sidebar Docs"
+  },
+  "sidebar.Docs.category.Community": {
+    "message": "Community",
+    "description": "The label for category Community in sidebar Docs"
+  }
+}

--- a/i18n/cn/docusaurus-theme-classic/footer.json
+++ b/i18n/cn/docusaurus-theme-classic/footer.json
@@ -1,0 +1,46 @@
+{
+  "link.title.Documentation": {
+    "message": "Documentation",
+    "description": "The title of the footer links column with title=Documentation in the footer"
+  },
+  "link.title.Community": {
+    "message": "Community",
+    "description": "The title of the footer links column with title=Community in the footer"
+  },
+  "link.title.More": {
+    "message": "More",
+    "description": "The title of the footer links column with title=More in the footer"
+  },
+  "link.item.label.Installation": {
+    "message": "Installation",
+    "description": "The label of footer link with label=Installation linking to /docs/category/getting-started"
+  },
+  "link.item.label.Discord": {
+    "message": "Discord",
+    "description": "The label of footer link with label=Discord linking to https://discord.com/invite/aCsmEV5RgA"
+  },
+  "link.item.label.GitHub": {
+    "message": "GitHub",
+    "description": "The label of footer link with label=GitHub linking to https://github.com/homarr-labs/homarr"
+  },
+  "link.item.label.Donate": {
+    "message": "Donate",
+    "description": "The label of footer link with label=Donate linking to https://opencollective.com/homarr"
+  },
+  "link.item.label.Blog": {
+    "message": "Blog",
+    "description": "The label of footer link with label=Blog linking to /blog"
+  },
+  "link.item.label.About us": {
+    "message": "About us",
+    "description": "The label of footer link with label=About us linking to /about-us"
+  },
+  "copyright": {
+    "message": "<span class=\"copyright_text\">Copyright © 2025 Homarr<span> — <a href=\"/docs/community/license\">License</a>",
+    "description": "The footer copyright"
+  },
+  "logo.alt": {
+    "message": "Homarr Logo",
+    "description": "The alt text of footer logo"
+  }
+}

--- a/i18n/cn/docusaurus-theme-classic/navbar.json
+++ b/i18n/cn/docusaurus-theme-classic/navbar.json
@@ -1,0 +1,58 @@
+{
+  "title": {
+    "message": "Homarr",
+    "description": "The title in the navbar"
+  },
+  "logo.alt": {
+    "message": "Homarr Logo",
+    "description": "The alt text of navbar logo"
+  },
+  "item.label.Documentation": {
+    "message": "Documentation",
+    "description": "Navbar item with label Documentation"
+  },
+  "item.label.Blog": {
+    "message": "Blog",
+    "description": "Navbar item with label Blog"
+  },
+  "item.label.About us": {
+    "message": "About us",
+    "description": "Navbar item with label About us"
+  },
+  "item.label.💴 Donate": {
+    "message": "💴 Donate",
+    "description": "Navbar item with label 💴 Donate"
+  },
+  "item.label.Community": {
+    "message": "Community",
+    "description": "Navbar item with label Community"
+  },
+  "item.label.Discord": {
+    "message": "Discord",
+    "description": "Navbar item with label Discord"
+  },
+  "item.label.GitHub": {
+    "message": "GitHub",
+    "description": "Navbar item with label GitHub"
+  },
+  "item.label.Answer Overflow": {
+    "message": "Answer Overflow",
+    "description": "Navbar item with label Answer Overflow"
+  },
+  "item.label.Community translations (Crowdin)": {
+    "message": "Community translations (Crowdin)",
+    "description": "Navbar item with label Community translations (Crowdin)"
+  },
+  "item.label.Reddit": {
+    "message": "Reddit",
+    "description": "Navbar item with label Reddit"
+  },
+  "item.label.OpenCollective": {
+    "message": "OpenCollective",
+    "description": "Navbar item with label OpenCollective"
+  },
+  "item.label.X / Twitter": {
+    "message": "X / Twitter",
+    "description": "Navbar item with label X / Twitter"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",
-    "serve": "docusaurus serve",
+    "serve": "docusaurus serve --no-open",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
     "api-dump-contributors": "node ./scripts/dump-contributors.mjs"

--- a/src/components/pages/home/hero/hero.tsx
+++ b/src/components/pages/home/hero/hero.tsx
@@ -3,6 +3,7 @@ import { IconDownload } from '@tabler/icons-react';
 import clsx from 'clsx';
 import styles from '../../../../pages/index.module.css';
 import { HeroCards } from './hero-cards';
+import Translate from '@docusaurus/Translate';
 
 export default function HomeHero() {
   return (
@@ -12,9 +13,11 @@ export default function HomeHero() {
           <h1 className="font-extrabold lg:text-7xl text-3xl">A simple, yet<br />powerful dashboard<br />for your
             server.</h1>
           <p className={'lg:text-2xl text-base'}>
-            A sleek, modern dashboard that puts all of your apps and services at your fingertips.
-            Control everything in one convenient location. Seamlessly integrates with the
-            apps you've added, providing you with valuable information.
+            <Translate>
+              A sleek, modern dashboard that puts all of your apps and services at your fingertips.
+              Control everything in one convenient location. Seamlessly integrates with the
+              apps you've added, providing you with valuable information.
+            </Translate>
           </p>
 
           <div className={'flex flex-nowrap gap-2'}>


### PR DESCRIPTION
- Added Simplified Chinese ('cn') to the i18n configuration with appropriate labels and HTML language settings.
- Introduced a locale dropdown in the navigation for language selection.
- Wrapped the home hero description in a Translate component for localization support.
- Updated the serve command in package.json to prevent automatic opening of the browser.

## Usage
To translate a message, you only need to wrap the string with <Translate /> , so 
```tsx
    <Translate>
              A sleek, modern dashboard that puts all of your apps and services at your fingertips.
              Control everything in one convenient location. Seamlessly integrates with the
              apps you've added, providing you with valuable information.
    </Translate>
```
just works ! Then it generates a key corresponding to it : 
```json
  "A sleek, modern dashboard that puts all of your apps and services at your fingertips. Control everything in one convenient location. Seamlessly integrates with the apps you've added, providing you with valuable information.": {
    "message": "光滑的现代仪表板，将所有应用程序和服务触手可及。在一个方便的位置控制所有内容。与您添加的应用程序无缝集成，为您提供有价值的信息。(Google translate)"
  },
  ```

## Notes
- To see the locale in dev mode you need to do `pnpm run dev --locale cn`
- We could add this to the same crowdin account and share the "translation memory" to make it faster to translate. 
- I don't think translation in another language than Chinese is necessary, such proposal should be rejected
> [!NOTE]
> The translation keys are **AUTOMATICALLY GENERATED** using `pnpm write-translations --locale cn` making it pain-free to create the json to translate. But it might be annoying for the person translating when we change the string (because the key will change) but we should ignore this. 

## Thoughts 
We could utilize the AI-translate feature with the context of the project on Crowdin to generate translations that are close to the final result, then leverage the frustrated Chinese users seeing wrong translations to ask them to translate 

## Preview 
![CleanShot 2025-07-23 at 11 42 31](https://github.com/user-attachments/assets/4139b0fb-4d4c-4de1-97dd-2cdb7db37666)
