### PR TITLE
ci: add release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,40 @@
+name: Release
+
+permissions: {}
+
+on:
+  repository_dispatch:
+    types: [trigger-release]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [22]
+    steps:
+      - name: Obtain token
+        id: obtainToken
+        uses: tibdex/github-app-token@v2
+        with:
+          private_key: ${{ secrets.HOMARR_DOCS_RELEASE_APP_PRIVATE_KEY }}
+          app_id: ${{ vars.HOMARR_DOCS_RELEASE_APP_ID }}
+      - name: Checkout code
+        env:
+          GITHUB_TOKEN: ${{ steps.obtainToken.outputs.token }}
+        uses: actions/checkout@v5
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'pnpm'
+      - run: pnpm install
+      - run: |
+          RAW_TAG="${{ github.event.client_payload.tag }}"
+          CLEAN_TAG="${RAW_TAG#v}"
+          pnpm run docusaurus docs:version $CLEAN_TAG
+      - uses: EndBug/add-and-commit@v9
+        with:
+          default_author: github_actor
+          message: 'docs: add version ${{ github.event.client_payload.tag }}'
+          push: true

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /node_modules
 /.pnp
 .pnp.js
+.pnpm-store/
 
 # testing
 /coverage


### PR DESCRIPTION
I tested it locally with `act repository_dispatch -W .github/workflows/release.yaml --eventpath event.json --secret-file .env --var HOMARR_DOCS_RELEASE_APP_ID=1187692`.

The next plan is to create a workflow that triggers this workflow once a release is published in the main repository