### PR TITLE
docs: fix typo in after-the-installation page

### DIFF
--- a/docs/getting-started/after-the-installation.mdx
+++ b/docs/getting-started/after-the-installation.mdx
@@ -42,7 +42,7 @@ You can either import a previous dashboard using the ZIP archive or start from s
 
 ![Screenshot of Step 1 onboarding](./img/onboarding-step-1.png)
 
-You may refresh anytime and continue from a different device - the onboarding is saved immediately on the server for your convinience.
+You may refresh anytime and continue from a different device - the onboarding is saved immediately on the server for your convenience.
 
 ### Starting from scratch
 Depending on your auth provider configuration you will either first see the admin user creation form or the external group creation form.

--- a/docs/getting-started/after-the-installation.mdx
+++ b/docs/getting-started/after-the-installation.mdx
@@ -42,7 +42,7 @@ You can either import a previous dashboard using the ZIP archive or start from s
 
 ![Screenshot of Step 1 onboarding](./img/onboarding-step-1.png)
 
-You may refresh anytime and continue from a different device - the onboarding is saved immideatly on the server for your convinience.
+You may refresh anytime and continue from a different device - the onboarding is saved immediately on the server for your convinience.
 
 ### Starting from scratch
 Depending on your auth provider configuration you will either first see the admin user creation form or the external group creation form.


### PR DESCRIPTION
Fixes some typos in the "After the installation" page under the "Getting started" section.