### PR TITLE
docs: add Umami Analytics integration and widget documentation

### DIFF
--- a/docs/integrations/umami/index.mdx
+++ b/docs/integrations/umami/index.mdx
@@ -1,0 +1,53 @@
+---
+title: 'Umami'
+description: 'Privacy-focused, open-source web analytics'
+hide_title: true
+---
+
+import { IntegrationHeader } from '@site/src/components/integrations/header';
+import { IntegrationCapabilites } from '@site/src/components/integrations/widgets';
+import { AddingIntegration } from '@site/src/components/integrations/adding';
+import { IntegrationSecrets } from '@site/src/components/integrations/secrets';
+import { umamiIntegration } from '.';
+import { umamiWidget } from '../../widgets/umami';
+
+<IntegrationHeader
+  integration={umamiIntegration}
+  categories={['Analytics']}
+/>
+
+### Widgets & Capabilities
+<IntegrationCapabilites
+  items={[
+    { widget: umamiWidget }
+  ]}
+/>
+
+### Adding the integration
+<AddingIntegration />
+
+:::tip URL configuration
+- **Umami Cloud:** Use `https://api.umami.is/v1`
+- **Self-hosted:** Use `http://your-umami-host:3000/api`
+:::
+
+### Secrets
+<IntegrationSecrets secrets={[
+  {
+    credentials: ['apiKey'],
+    steps: [
+      'Log in to your Umami instance (or Umami Cloud at https://cloud.umami.is)',
+      'Open Settings → API Keys',
+      'Click "Create API key"',
+      'Enter a name, e.g. "Homarr", and save',
+      'Copy the generated API key into Homarr',
+    ]
+  },
+  {
+    credentials: ['username', 'password'],
+    steps: [
+      'Use the username and password of your Umami account',
+      'Note: username/password auth is for self-hosted instances only — Umami Cloud requires an API key',
+    ]
+  }
+]} />

--- a/docs/integrations/umami/index.ts
+++ b/docs/integrations/umami/index.ts
@@ -1,0 +1,8 @@
+import { IntegrationDefinition } from '@site/src/types';
+
+export const umamiIntegration: IntegrationDefinition = {
+  name: 'Umami',
+  description: 'Privacy-focused, open-source web analytics',
+  iconUrl: 'https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/svg/umami.svg',
+  path: '../../integrations/umami',
+};

--- a/docs/widgets/umami/index.mdx
+++ b/docs/widgets/umami/index.mdx
@@ -1,0 +1,49 @@
+---
+title: 'Umami Analytics'
+description: 'Display visitor stats from your Umami analytics instance'
+hide_title: true
+---
+
+import { WidgetHeader } from '@site/src/components/widgets/header';
+import { AddingWidget } from '@site/src/components/widgets/adding';
+import { WidgetConfig } from '@site/src/components/widgets/configuration';
+import { WidgetIntegrations } from '@site/src/components/widgets/integrations';
+import { umamiWidget } from '.';
+import { umamiIntegration } from '@site/docs/integrations/umami';
+
+<WidgetHeader
+  widget={umamiWidget}
+  categories={['Analytics']}
+/>
+
+The Umami Analytics widget displays key visitor metrics from a website tracked by your [Umami](https://umami.is) instance — pageviews, unique visitors, visits, bounce rate, avg. visit duration, and real-time active visitor count. The widget body can be switched between a visitor/event chart, a multi-event chart, and ranked top pages or referrers lists.
+
+### Supported Integrations
+
+<WidgetIntegrations items={[{
+  integration: umamiIntegration,
+}]} />
+
+### Adding the widget
+
+<AddingWidget />
+
+### Configuration
+
+<WidgetConfig configuration={umamiWidget.configuration} />
+
+### View modes
+
+| View | Description |
+|---|---|
+| **Chart** | Bar chart or sparkline of unique visitors over the selected time frame. Optionally overlay a single named event as a second series. |
+| **Events chart** | Multi-select one or more named events and chart each as its own colored series — no visitor baseline. Supports bar and sparkline. |
+| **Top pages** | Ranked list of URLs by pageview count for the selected time frame. |
+| **Top referrers** | Ranked list of referrer sources by session count. Direct traffic (no referrer) is labeled "Direct". |
+
+### Notes
+
+- The **Website** selector is populated automatically from the websites tracked by the connected Umami integration. No manual ID entry is required.
+- **Event names** for the Event and Events selectors are fetched from Umami's metrics API based on the past 30 days of activity.
+- Active visitor count refreshes every 30 seconds independently of the main data cache.
+- All other data is cached for 5 minutes and refreshed in the background by a cron job.

--- a/docs/widgets/umami/index.ts
+++ b/docs/widgets/umami/index.ts
@@ -1,0 +1,73 @@
+import { WidgetDefinition } from '@site/src/types';
+import { IconChartBar } from '@tabler/icons-react';
+
+export const umamiWidget: WidgetDefinition = {
+  icon: IconChartBar,
+  name: 'Umami Analytics',
+  description: 'Display visitor stats from your Umami analytics instance',
+  path: '../../widgets/umami',
+  configuration: {
+    items: [
+      {
+        name: 'Website',
+        description: 'Select a website tracked by your Umami instance. Populated automatically from the connected integration.',
+        values: 'Website selector',
+        defaultValue: 'None',
+      },
+      {
+        name: 'Time frame',
+        description: 'The time period to display visitor data for',
+        values: {
+          type: 'select',
+          options: ['Today', 'Last 24 hours', 'Last 7 days', 'Last 30 days', 'This month', 'Last month'],
+        },
+        defaultValue: 'Last 24 hours',
+      },
+      {
+        name: 'View',
+        description: 'What to display in the widget body. Visible once a website is selected.',
+        values: {
+          type: 'select',
+          options: ['Chart', 'Events chart', 'Top pages', 'Top referrers'],
+        },
+        defaultValue: 'Chart',
+      },
+      {
+        name: 'Chart type',
+        description: 'Display style for the chart. Visible when View is "Chart" or "Events chart".',
+        values: {
+          type: 'select',
+          options: ['Bar chart', 'Sparkline'],
+        },
+        defaultValue: 'Bar chart',
+      },
+      {
+        name: 'Chart style',
+        description: 'How to render the event series alongside visitors. Visible when View is "Chart", Chart type is "Bar chart", and an Event is selected.',
+        values: {
+          type: 'select',
+          options: ['Side by side', 'Overlay (subset)'],
+        },
+        defaultValue: 'Side by side',
+      },
+      {
+        name: 'Event',
+        description: 'Overlay a single named event on the visitor chart. Populated from event names recorded by Umami. Visible when View is "Chart".',
+        values: 'Event name selector',
+        defaultValue: 'None',
+      },
+      {
+        name: 'Events',
+        description: 'Select one or more events to plot as individual series with no visitors baseline. Populated from event names recorded by Umami. Visible when View is "Events chart".',
+        values: 'Multi-select event name selector',
+        defaultValue: 'None',
+      },
+      {
+        name: 'Items to show',
+        description: 'Number of top items to display. Visible when View is "Top pages" or "Top referrers".',
+        values: 'Number (1–500)',
+        defaultValue: '5',
+      },
+    ],
+  },
+};


### PR DESCRIPTION
## Summary

Adds integration and widget documentation for the Umami Analytics integration.

- `docs/integrations/umami/` — authentication setup (API key + username/password tabs), URL guidance for Cloud vs self-hosted
- `docs/widgets/umami/` — full configuration reference, view modes, behavior notes

Closes #519 

Code PR: homarr-labs/homarr#5362