### PR TITLE
docs: add Coolify integration documentation

### DIFF
--- a/docs/integrations/coolify/index.mdx
+++ b/docs/integrations/coolify/index.mdx
@@ -1,0 +1,46 @@
+---
+title: 'Coolify'
+description: 'Self-hosted PaaS and deployment platform'
+hide_title: true
+---
+
+import { IntegrationHeader } from '@site/src/components/integrations/header';
+import { IntegrationCapabilites } from '@site/src/components/integrations/widgets';
+import { AddingIntegration } from '@site/src/components/integrations/adding';
+import { IntegrationSecrets } from '@site/src/components/integrations/secrets';
+import { coolifyIntegration } from '.';
+import { coolifyWidget } from '../../widgets/coolify';
+
+<IntegrationHeader
+  integration={coolifyIntegration}
+  categories={['System monitoring', 'Deployment']}
+/>
+
+### Widgets & Capabilities
+<IntegrationCapabilites
+  items={[
+    { widget: coolifyWidget }
+  ]}
+/>
+
+### Adding the integration
+<AddingIntegration />
+
+:::info URL configuration
+Use the root URL of your Coolify instance, for example `https://coolify.example.com`. Homarr calls Coolify endpoints under `/api` and `/api/v1` automatically.
+:::
+
+### Secrets
+<IntegrationSecrets secrets={[{
+  credentials: ['apiKey'],
+  steps: [
+    'Open your Coolify instance and make sure you are in the team you want Homarr to monitor.',
+    (<span>Enable API access under <strong>Settings &gt; Advanced</strong> if it is disabled.</span>),
+    (<span>Go to <strong>Security &gt; API Tokens</strong>.</span>),
+    'Enter a name, e.g. "Homarr".',
+    (<span>Select the <code>read</code> permission. The Coolify widget only reads version, server, project, application, and service data.</span>),
+    'Click "Create".',
+    'Copy the generated token immediately. Coolify only shows it once.',
+    'Paste the token into the API Key field in Homarr.'
+  ]
+}]} />

--- a/docs/integrations/coolify/index.ts
+++ b/docs/integrations/coolify/index.ts
@@ -1,0 +1,8 @@
+import { IntegrationDefinition } from '@site/src/types';
+
+export const coolifyIntegration: IntegrationDefinition = {
+  name: 'Coolify',
+  description: 'Self-hosted PaaS and deployment platform',
+  iconUrl: 'https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/svg/coolify.svg',
+  path: '../../integrations/coolify',
+};

--- a/docs/widgets/coolify/index.mdx
+++ b/docs/widgets/coolify/index.mdx
@@ -1,0 +1,47 @@
+---
+title: 'Coolify'
+description: 'Overview of your Coolify instance with servers, applications, and services.'
+hide_title: true
+---
+
+import { WidgetHeader } from '@site/src/components/widgets/header';
+import { AddingWidget } from '@site/src/components/widgets/adding';
+import { WidgetConfig } from '@site/src/components/widgets/configuration';
+import { WidgetIntegrations } from '@site/src/components/widgets/integrations';
+import { coolifyWidget } from '.';
+import { coolifyIntegration } from '@site/docs/integrations/coolify';
+
+<WidgetHeader
+  widget={coolifyWidget}
+  categories={['System monitoring', 'Deployment']}
+/>
+
+The Coolify widget displays a compact overview of your Coolify instance. It can show servers, applications, and services with status indicators, project and environment context, direct links to Coolify, and the installed Coolify version.
+
+### Supported Integrations
+
+<WidgetIntegrations items={[{
+  integration: coolifyIntegration,
+}]} />
+
+### Adding the widget
+
+<AddingWidget />
+
+### Configuration
+
+<WidgetConfig configuration={coolifyWidget.configuration} />
+
+### Sections
+
+| Section | Description |
+|---|---|
+| **Servers** | Lists Coolify servers, reachability status, and application/service counts per server. |
+| **Applications** | Lists applications with runtime status, project and environment context, public URL links, Coolify dashboard links, and log links. |
+| **Services** | Lists services with runtime status, project and environment context, public URL links, Coolify dashboard links, and log links. |
+
+### Notes
+
+- The widget supports one or more Coolify integrations. With multiple integrations, each instance is shown as a separate card.
+- The Coolify API token is team-scoped. Homarr only shows resources available to the team where the token was created.
+- Data is cached for 30 seconds and refreshed in the background.

--- a/docs/widgets/coolify/index.ts
+++ b/docs/widgets/coolify/index.ts
@@ -1,0 +1,32 @@
+import { WidgetDefinition } from '@site/src/types';
+import { IconCloud } from '@tabler/icons-react';
+
+export const coolifyWidget: WidgetDefinition = {
+  icon: IconCloud,
+  name: 'Coolify',
+  description: 'Overview of your Coolify instance with servers, applications, and services.',
+  path: '../../widgets/coolify',
+  configuration: {
+    items: [
+      {
+        name: 'Show servers',
+        description: 'Display the servers section with reachability status and resource counts.',
+        values: { type: 'boolean' },
+        defaultValue: 'yes',
+      },
+      {
+        name: 'Show applications',
+        description:
+          'Display the applications section with status, project, environment, and links.',
+        values: { type: 'boolean' },
+        defaultValue: 'yes',
+      },
+      {
+        name: 'Show services',
+        description: 'Display the services section with status, project, environment, and links.',
+        values: { type: 'boolean' },
+        defaultValue: 'yes',
+      },
+    ],
+  },
+};

--- a/versioned_docs/version-1.63.0/integrations/coolify/index.mdx
+++ b/versioned_docs/version-1.63.0/integrations/coolify/index.mdx
@@ -1,0 +1,46 @@
+---
+title: 'Coolify'
+description: 'Self-hosted PaaS and deployment platform'
+hide_title: true
+---
+
+import { IntegrationHeader } from '@site/src/components/integrations/header';
+import { IntegrationCapabilites } from '@site/src/components/integrations/widgets';
+import { AddingIntegration } from '@site/src/components/integrations/adding';
+import { IntegrationSecrets } from '@site/src/components/integrations/secrets';
+import { coolifyIntegration } from '.';
+import { coolifyWidget } from '../../widgets/coolify';
+
+<IntegrationHeader
+  integration={coolifyIntegration}
+  categories={['System monitoring', 'Deployment']}
+/>
+
+### Widgets & Capabilities
+<IntegrationCapabilites
+  items={[
+    { widget: coolifyWidget }
+  ]}
+/>
+
+### Adding the integration
+<AddingIntegration />
+
+:::info URL configuration
+Use the root URL of your Coolify instance, for example `https://coolify.example.com`. Homarr calls Coolify endpoints under `/api` and `/api/v1` automatically.
+:::
+
+### Secrets
+<IntegrationSecrets secrets={[{
+  credentials: ['apiKey'],
+  steps: [
+    'Open your Coolify instance and make sure you are in the team you want Homarr to monitor.',
+    (<span>Enable API access under <strong>Settings &gt; Advanced</strong> if it is disabled.</span>),
+    (<span>Go to <strong>Security &gt; API Tokens</strong>.</span>),
+    'Enter a name, e.g. "Homarr".',
+    (<span>Select the <code>read</code> permission. The Coolify widget only reads version, server, project, application, and service data.</span>),
+    'Click "Create".',
+    'Copy the generated token immediately. Coolify only shows it once.',
+    'Paste the token into the API Key field in Homarr.'
+  ]
+}]} />

--- a/versioned_docs/version-1.63.0/integrations/coolify/index.ts
+++ b/versioned_docs/version-1.63.0/integrations/coolify/index.ts
@@ -1,0 +1,8 @@
+import { IntegrationDefinition } from '@site/src/types';
+
+export const coolifyIntegration: IntegrationDefinition = {
+  name: 'Coolify',
+  description: 'Self-hosted PaaS and deployment platform',
+  iconUrl: 'https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/svg/coolify.svg',
+  path: '../../integrations/coolify',
+};

--- a/versioned_docs/version-1.63.0/widgets/coolify/index.mdx
+++ b/versioned_docs/version-1.63.0/widgets/coolify/index.mdx
@@ -1,0 +1,47 @@
+---
+title: 'Coolify'
+description: 'Overview of your Coolify instance with servers, applications, and services.'
+hide_title: true
+---
+
+import { WidgetHeader } from '@site/src/components/widgets/header';
+import { AddingWidget } from '@site/src/components/widgets/adding';
+import { WidgetConfig } from '@site/src/components/widgets/configuration';
+import { WidgetIntegrations } from '@site/src/components/widgets/integrations';
+import { coolifyWidget } from '.';
+import { coolifyIntegration } from '@site/docs/integrations/coolify';
+
+<WidgetHeader
+  widget={coolifyWidget}
+  categories={['System monitoring', 'Deployment']}
+/>
+
+The Coolify widget displays a compact overview of your Coolify instance. It can show servers, applications, and services with status indicators, project and environment context, direct links to Coolify, and the installed Coolify version.
+
+### Supported Integrations
+
+<WidgetIntegrations items={[{
+  integration: coolifyIntegration,
+}]} />
+
+### Adding the widget
+
+<AddingWidget />
+
+### Configuration
+
+<WidgetConfig configuration={coolifyWidget.configuration} />
+
+### Sections
+
+| Section | Description |
+|---|---|
+| **Servers** | Lists Coolify servers, reachability status, and application/service counts per server. |
+| **Applications** | Lists applications with runtime status, project and environment context, public URL links, Coolify dashboard links, and log links. |
+| **Services** | Lists services with runtime status, project and environment context, public URL links, Coolify dashboard links, and log links. |
+
+### Notes
+
+- The widget supports one or more Coolify integrations. With multiple integrations, each instance is shown as a separate card.
+- The Coolify API token is team-scoped. Homarr only shows resources available to the team where the token was created.
+- Data is cached for 30 seconds and refreshed in the background.

--- a/versioned_docs/version-1.63.0/widgets/coolify/index.ts
+++ b/versioned_docs/version-1.63.0/widgets/coolify/index.ts
@@ -1,0 +1,32 @@
+import { WidgetDefinition } from '@site/src/types';
+import { IconCloud } from '@tabler/icons-react';
+
+export const coolifyWidget: WidgetDefinition = {
+  icon: IconCloud,
+  name: 'Coolify',
+  description: 'Overview of your Coolify instance with servers, applications, and services.',
+  path: '../../widgets/coolify',
+  configuration: {
+    items: [
+      {
+        name: 'Show servers',
+        description: 'Display the servers section with reachability status and resource counts.',
+        values: { type: 'boolean' },
+        defaultValue: 'yes',
+      },
+      {
+        name: 'Show applications',
+        description:
+          'Display the applications section with status, project, environment, and links.',
+        values: { type: 'boolean' },
+        defaultValue: 'yes',
+      },
+      {
+        name: 'Show services',
+        description: 'Display the services section with status, project, environment, and links.',
+        values: { type: 'boolean' },
+        defaultValue: 'yes',
+      },
+    ],
+  },
+};


### PR DESCRIPTION
## Summary
- add Coolify integration documentation
- add Coolify widget documentation
- include the same pages in the latest versioned docs so /docs/integrations/coolify resolves for the current docs version

### Coolify integration documentation
<img width="1425" height="1924" alt="coolify-integration-docs-full" src="https://github.com/user-attachments/assets/06b9230c-e4e3-4b90-bdf6-e0541526fba7" />

### Coolify widget documentation
<img width="1425" height="2137" alt="coolify-widget-docs-full" src="https://github.com/user-attachments/assets/3a29b649-b7a5-41f4-bd38-172b30e27e60" />

## Verification
- checked git diff for whitespace issues
- verified the page locally with Docusaurus dev server at /docs/integrations/coolify
- captured a local preview screenshot at /tmp/opencode/coolify-integration-docs.png

Notes: repository-wide typecheck/prettier checks currently fail on existing unrelated baseline issues.