### PR TITLE
feat(docs): add Gotify integration documentation

### DIFF
--- a/docs/integrations/gotify/index.mdx
+++ b/docs/integrations/gotify/index.mdx
@@ -1,0 +1,33 @@
+---
+title: 'Gotify'
+description: "Gotify is a simple, self-hosted server for sending and receiving messages in real time."
+hide_title: true
+---
+
+import { notificationsWidget } from '@site/docs/widgets/notifications';
+import { AddingIntegration } from '@site/src/components/integrations/adding';
+import { IntegrationHeader } from '@site/src/components/integrations/header';
+import { IntegrationSecrets } from '@site/src/components/integrations/secrets';
+import { IntegrationCapabilites } from '@site/src/components/integrations/widgets';
+import { gotifyIntegration } from '.';
+
+<IntegrationHeader
+    integration={gotifyIntegration}
+    categories={['Notifications', 'Messaging']}
+/>
+
+### Widgets & Capabilities
+<IntegrationCapabilites
+    items={[{
+        widget: notificationsWidget
+    }]}
+/>
+
+### Adding the integration
+<AddingIntegration />
+
+### Secrets
+<IntegrationSecrets secrets={[{
+    credentials: ['username', 'password'],
+    steps: []
+}]} />

--- a/docs/integrations/gotify/index.ts
+++ b/docs/integrations/gotify/index.ts
@@ -1,0 +1,9 @@
+import { IntegrationDefinition } from '@site/src/types';
+
+export const gotifyIntegration: IntegrationDefinition = {
+  name: 'Gotify',
+  description:
+    'Gotify is a simple, self-hosted server for sending and receiving messages in real time.',
+  iconUrl: 'https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/gotify.svg',
+  path: '../../integrations/gotify',
+};

--- a/docs/widgets/notifications/index.mdx
+++ b/docs/widgets/notifications/index.mdx
@@ -13,7 +13,8 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import { notificationsWidget } from '.';
 import { ntfyIntegration } from '@site/docs/integrations/ntfy';
-import { nextcloudIntegration } from '@site/docs/integrations/nextcloud'
+import { nextcloudIntegration } from '@site/docs/integrations/nextcloud';
+import { gotifyIntegration } from '@site/docs/integrations/gotify';
 
 <WidgetHeader
   widget={notificationsWidget}
@@ -33,7 +34,8 @@ import notificationsScreenshot from './img/notifications.png';
 <WidgetIntegrations
   items={[
     { integration: ntfyIntegration },
-    { integration: nextcloudIntegration }
+    { integration: nextcloudIntegration },
+    { integration: gotifyIntegration }
   ]}
 />
 


### PR DESCRIPTION
Relates to homarr-labs/homarr#4186

Adds documentation for the new Gotify notifications integration,
following the same structure as existing integration docs (ntfy, nextcloud).

- `index.ts` — integration definition with name, description, icon URL
  (sourced from `homarr-labs/dashboard-icons`) and doc path.
- `index.mdx` — integration page documenting:
  - Widget capabilities (Notifications widget)
  - How to add the integration
  - Required secrets: `username` and `password` (HTTP Basic Auth)

- Imports `gotifyIntegration` and adds it to the `WidgetIntegrations`
  supported integrations list alongside ntfy and Nextcloud.
- Also fixes a missing semicolon on the `nextcloudIntegration` import.