### PR TITLE
docs(truenas): document api key authentication and update credential setup

### DIFF
--- a/docs/integrations/truenas/index.mdx
+++ b/docs/integrations/truenas/index.mdx
@@ -11,6 +11,7 @@ import { IntegrationSecrets } from '@site/src/components/integrations/secrets';
 import { truenasIntegration } from '.';
 import { systemResourcesWidget } from '@site/docs/widgets/system-resources';
 import { healthMonitoringWidget } from '@site/docs/widgets/health-monitoring';
+import Alert from '@theme/Admonition';
 
 
 <IntegrationHeader
@@ -29,12 +30,32 @@ import { healthMonitoringWidget } from '@site/docs/widgets/health-monitoring';
 ### Adding the integration
 <AddingIntegration />
 
+<Alert type="info" title="Use the HTTPS address">
+    TrueNAS only serves its API over HTTPS, so enter the <code>https://</code> URL of your TrueNAS web interface. If it uses a self-signed certificate (the default), add it under <a href="/docs/management/certificates">Management &gt; Tools &gt; Certificates</a> so Homarr can establish the connection.
+</Alert>
+
 ### Secrets
-<IntegrationSecrets secrets={[{
-    credentials: ['username', 'password'],
-    steps: [
-      "Create a user on the TrueNAS UI with a secure password at \"Credentials\" > \"Users\" > \"Add User\".",
-      "Add the auxiliary group \"auxiliary_administrator\" to the user.",
-      "Save the user and create an integration in Homarr with the previous defined credentials"
-    ],
-}]} />
+<IntegrationSecrets secrets={[
+    {
+        credentials: ['apiKey'],
+        header: <Alert type="tip" title="Recommended">
+            API key authentication is the recommended method. It works across current TrueNAS versions and does not depend on user group membership.
+        </Alert>,
+        steps: [
+            "In the TrueNAS web interface, click your user avatar in the top-right corner and select \"API Keys\".",
+            "Click \"Add\", give the key a name such as \"Homarr\", and confirm.",
+            "Copy the generated key immediately — TrueNAS only shows it once — and paste it as the API Key when creating the integration in Homarr.",
+        ],
+    },
+    {
+        credentials: ['username', 'password'],
+        steps: [
+            "In the TrueNAS web interface, go to \"Credentials\" > \"Users\" > \"Add\" and create a user with a secure password.",
+            "Grant the user administrative access so Homarr can read system, pool, and reporting data.",
+            "Save the user and create the integration in Homarr with these credentials.",
+        ],
+        body: <Alert type="caution" title="Administrative access required">
+            The account must have administrative API access. The <code>auxiliary_administrator</code> group was removed in TrueNAS 25.10; on that version or newer, use API key authentication instead, or assign the user a full-admin role.
+        </Alert>,
+    },
+]} />


### PR DESCRIPTION
## Summary

Updates the TrueNAS integration documentation to match the integration changes in homarr-labs/homarr#5861.

- Add **API key** authentication as the recommended method, with steps to create a key in the TrueNAS UI.
- Remove the obsolete *"add the `auxiliary_administrator` group"* step - that group was removed in TrueNAS 25.10 - and note that the username/password account needs administrative API access instead.
- Add a note to use the `https://` URL and, for the default self-signed certificate, to trust it via `Management > Tools > Certificates` so Homarr can connect.

## Context

Documents homarr-labs/homarr#5861 and relates to homarr-labs/homarr#4206 (TrueNAS integration not connecting on newer versions). Verified the API-key and username/password flows live against a TrueNAS 25.04 server.
