### PR TITLE
docs: remove stale search engine integration section after spotlight mode

### DIFF
--- a/docs/integrations/jellyseerr/index.mdx
+++ b/docs/integrations/jellyseerr/index.mdx
@@ -28,8 +28,8 @@ import { mediaRequestStatsWidget } from '@site/docs/widgets/media-request-stats'
     }, {
         capability: {
             icon: IconSearch,
-            name: "Search",
-            description: "Search for media and request it via Spotlight",
+            name: "Media Search",
+            description: "Search for movies and TV shows directly from Spotlight and request them.",
             path: "../../management/search-engines/#media-request-search"
         }
     }]}

--- a/docs/integrations/overseerr/index.mdx
+++ b/docs/integrations/overseerr/index.mdx
@@ -28,8 +28,8 @@ import { mediaRequestStatsWidget } from '@site/docs/widgets/media-request-stats'
     }, {
         capability: {
             icon: IconSearch,
-            name: "Search",
-            description: "Search for media and request it via Spotlight",
+            name: "Media Search",
+            description: "Search for movies and TV shows directly from Spotlight and request them.",
             path: "../../management/search-engines/#media-request-search"
         }
     }]}

--- a/docs/integrations/seerr/index.mdx
+++ b/docs/integrations/seerr/index.mdx
@@ -28,8 +28,8 @@ import { mediaRequestStatsWidget } from '@site/docs/widgets/media-request-stats'
     }, {
         capability: {
             icon: IconSearch,
-            name: "Search",
-            description: "Search for media and request it via Spotlight",
+            name: "Media Search",
+            description: "Search for movies and TV shows directly from Spotlight and request them.",
             path: "../../management/search-engines/#media-request-search"
         }
     }]}

--- a/docs/management/search-engines/index.mdx
+++ b/docs/management/search-engines/index.mdx
@@ -5,17 +5,12 @@ tags:
   - Search
 ---
 
-import { jellyseerrIntegration } from '@site/docs/integrations/jellyseerr';
-import { WidgetIntegrations } from '@site/src/components/widgets/integrations';
-import { overseerrIntegration } from '@site/docs/integrations/overseerr';
-
 # Search Engines
 Using the search engines, terms can be quickly searched simply by opening the search bar at the top or using the keyboard shortcut `CTRL + K`.
 
 ![](./img/search-engines.png)
 
 You can add any search engine that has a search URL that accepts a search term as a parameter.
-Additionally some integrations have a built-in search functionality, for more information see below.
 
 ## Create search engine
 To create a custom search engine, you can click the button at the top of the page.
@@ -43,18 +38,6 @@ Homarr will replace the ``%s`` with the term that the user entered.
 - DuckDuckGo: ``https://duckduckgo.com/?q=%s``
 - Bing: ``https://www.bing.com/search?q=%s``
 - YouTube: ``https://www.youtube.com/results?search_query=%s``
-
-#### Integration
-
-The following integrations support a search functionality and can be selected here:
-
-<WidgetIntegrations items={[{
-  integration: jellyseerrIntegration,
-  note: "Search for movies and TV shows in Jellyseerr and request them."
-}, {
-  integration: overseerrIntegration,
-  note: "Search for movies and TV shows in Overseerr and request them."
-}]} />
 
 ## Media request search
 


### PR DESCRIPTION
## Summary

Follow-up cleanup after #566, which already documented media request search as a first-class Spotlight mode.

This PR removes the outdated search engine **Integration** section (which incorrectly implied Jellyseerr/Overseerr must be configured as search engine entries) and renames the integration capability to **Media Search** with a clearer description linking to the `#media-request-search` section.

## Supersedes

Most of the original scope in this branch was covered by #566 (full Spotlight mode docs, widget updates, availability indicators). This PR now only contains the remaining alignment fixes.

## Related

- homarr-labs/homarr#5823
- #566