### PR TITLE
docs(onboarding): document integration setup with Docker discovery and URL templating

### DIFF
--- a/docs/getting-started/after-the-installation.mdx
+++ b/docs/getting-started/after-the-installation.mdx
@@ -66,6 +66,32 @@ Here you can also disable analytics. Please note that our analytics are completl
 
 <img src={imageStartFromScratchStepServerSettings} alt={"Screenshot of analytics and indexing settings in the onboarding"} width={300} />
 
+### Setting up integrations
+
+After configuring server settings, the onboarding guides you through setting up your integrations.
+
+#### Docker service discovery
+If Docker is available (socket mounted), Homarr automatically detects running containers and matches them to known integration types.
+Matching integrations are pre-selected in the integration list, saving you from manually picking each one.
+
+#### URL templating
+You can define a base URL template to auto-fill integration URLs in bulk.
+Two modes are supported:
+- **Subdomain mode** — e.g. `{app}.example.com` where `{app}` is replaced with the integration name
+- **Port mode** — e.g. `192.168.1.1:{port}` where `{port}` is replaced with the integration's default port
+
+#### API key helper links
+For integrations that require API keys (such as Sonarr, Radarr, SABnzbd, or Seerr), a helper link opens the relevant settings page in the target application so you can quickly copy your key.
+
+#### Creating apps from Docker containers
+You can optionally auto-create bookmark apps for all discovered Docker containers, making them immediately available on your board.
+
+:::note
+
+Some niche and registry integrations (GitHub, npm, Docker Hub, GitLab, Codeberg, LinuxServer.io, GHCR, Quay, Search.ch) are hidden from the onboarding selection grid but remain available on the manage integrations page.
+
+:::
+
 After this step, you finished the onboarding.
 The onboarding can no longer be started again.
 From here you can click on one of the provided links to continue your journey.


### PR DESCRIPTION
## Summary

Documents the enhanced onboarding integration step from homarr-labs/homarr#5607:

- **Docker service discovery**: auto-detect running containers and match to integration types
- **URL templating**: subdomain and port modes for bulk URL configuration
- **API key helper links**: direct links to integration settings pages
- **Docker app creation**: auto-create bookmark apps from discovered containers
- **Curated onboarding list**: notes that niche integrations are hidden from onboarding

## Files changed

- `docs/getting-started/after-the-installation.mdx` — new "Setting up integrations" section