### PR TITLE
docs(onboarding): document guided management and board tours

### DIFF
--- a/docs/getting-started/after-the-installation.mdx
+++ b/docs/getting-started/after-the-installation.mdx
@@ -298,6 +298,23 @@ You cannot reduce their horizontal width.
 
 :::
 
+## Guided tours
+
+After completing the onboarding, Homarr provides interactive guided tours to help you discover key features.
+
+### Management tour
+When you first visit the management area (`/manage`), Homarr walks you through the main pages: boards, apps, integrations, and users (admin only).
+Each page highlights the list view and the create action so you know where to find and add things.
+
+### Board tour
+When you first open a board, a tour highlights the board header elements: search, edit mode, settings, board switcher, and user menu.
+
+### Tour controls
+- Press **Enter** (or click **Next**) to advance through tour steps
+- Tours auto-start on first visit and do not repeat once completed
+- Tours are skipped on mobile screens (below `sm` breakpoint)
+- You can **reset tours** from the user settings page under **Manage > Users > [Your user] > General**
+
 ## Next steps
 You're done with the basic setup 🔥. Now it's time to organize and customize even more.
 We highly recommend you to experiment with different options, styles and configurations.


### PR DESCRIPTION
## Summary

Documents the interactive guided tours from homarr-labs/homarr#5756:

- **Management tour**: walks new users through boards, apps, integrations, and users pages
- **Board tour**: highlights board header elements (search, edit, settings, switcher, user menu)
- **Tour controls**: Enter key to advance, auto-start on first visit, mobile skip, reset from user settings

## Files changed

- `docs/getting-started/after-the-installation.mdx` — new "Guided tours" section