### PR TITLE
docs(search): document media request search as first-class spotlight mode

### DIFF
--- a/docs/integrations/jellyseerr/index.mdx
+++ b/docs/integrations/jellyseerr/index.mdx
@@ -29,8 +29,8 @@ import { mediaRequestStatsWidget } from '@site/docs/widgets/media-request-stats'
         capability: {
             icon: IconSearch,
             name: "Search",
-            description: "Search for media and request it",
-            path: "../../management/search-engines/#integration"
+            description: "Search for media and request it via Spotlight",
+            path: "../../management/search-engines/#media-request-search"
         }
     }]}
 />

--- a/docs/integrations/overseerr/index.mdx
+++ b/docs/integrations/overseerr/index.mdx
@@ -29,8 +29,8 @@ import { mediaRequestStatsWidget } from '@site/docs/widgets/media-request-stats'
         capability: {
             icon: IconSearch,
             name: "Search",
-            description: "Search for media and request it",
-            path: "../../management/search-engines/#integration"
+            description: "Search for media and request it via Spotlight",
+            path: "../../management/search-engines/#media-request-search"
         }
     }]}
 />

--- a/docs/integrations/seerr/index.mdx
+++ b/docs/integrations/seerr/index.mdx
@@ -29,8 +29,8 @@ import { mediaRequestStatsWidget } from '@site/docs/widgets/media-request-stats'
         capability: {
             icon: IconSearch,
             name: "Search",
-            description: "Search for media and request it",
-            path: "../../management/search-engines/#integration"
+            description: "Search for media and request it via Spotlight",
+            path: "../../management/search-engines/#media-request-search"
         }
     }]}
 />

--- a/docs/management/search-engines/index.mdx
+++ b/docs/management/search-engines/index.mdx
@@ -55,3 +55,25 @@ The following integrations support a search functionality and can be selected he
   integration: overseerrIntegration,
   note: "Search for movies and TV shows in Overseerr and request them."
 }]} />
+
+## Media request search
+
+Jellyseerr, Overseerr, and Seerr integrations have a dedicated **Spotlight mode** for searching and requesting media.
+This mode does not require creating a search engine entry — it is available automatically when you have a compatible integration configured.
+
+You can access it from:
+- The **Modes list** in Spotlight (opened with `CTRL + K`)
+- The **search button** on the media request list and stats widgets
+
+### Availability indicators
+
+Search results display colored status badges showing the media's current state in your integration:
+- **Available** — fully available in your media library
+- **Partial** — some content (e.g. seasons) is available
+- **Processing** — currently being downloaded or processed
+- **Requested** — requested but not yet available
+
+### Requesting TV show seasons
+
+For partially available TV shows, you can request additional seasons.
+The request modal shows which seasons are already requested (marked with a status badge and not selectable), so you can select only the missing seasons.

--- a/docs/widgets/media-request-list/index.mdx
+++ b/docs/widgets/media-request-list/index.mdx
@@ -39,7 +39,8 @@ import mediaRequestList from './img/list.png';
 
 ### Interactions
 
--Approve / decline a request by clicking on the thumbs up or down icon.
+- Approve / decline a request by clicking on the thumbs up or down icon.
+- Hover over the widget to reveal a **search button** that opens Spotlight in media request search mode, scoped to the widget's integrations.
 
 ### Adding the widget
 

--- a/docs/widgets/media-request-stats/index.mdx
+++ b/docs/widgets/media-request-stats/index.mdx
@@ -37,6 +37,10 @@ import mediaRequestStats from './img/stats.png';
 
 <img src={mediaRequestStats} alt="media-request-stats" width={256} height={256} />
 
+### Interactions
+
+- Hover over the widget to reveal a **search button** that opens Spotlight in media request search mode, scoped to the widget's integrations.
+
 ### Adding the widget
 
 <AddingWidget />


### PR DESCRIPTION
## Summary

Documents the new media request spotlight mode from homarr-labs/homarr#5823:

- **Dedicated spotlight mode**: Jellyseerr, Overseerr, and Seerr integrations now have a first-class search mode in Spotlight, no search engine entry needed
- **Availability indicators**: colored badges showing media status (Available, Partial, Processing, Requested)
- **TV show re-requests**: request additional seasons for partially available shows
- **Widget search buttons**: media request list and stats widgets have hover-revealed search buttons scoped to their integrations
- **Updated integration links**: Jellyseerr, Overseerr, and Seerr capability links now point to the new media request search section

## Files changed

- `docs/management/search-engines/index.mdx` — new "Media request search" section
- `docs/widgets/media-request-list/index.mdx` — added search button interaction
- `docs/widgets/media-request-stats/index.mdx` — added search button interaction
- `docs/integrations/jellyseerr/index.mdx` — updated capability link
- `docs/integrations/overseerr/index.mdx` — updated capability link
- `docs/integrations/seerr/index.mdx` — updated capability link