### PR TITLE
docs: add Uptime Kuma, Audiobookshelf, Paperless-ngx, and Navidrome documentation

### DIFF
--- a/docs/integrations/audiobookshelf/index.mdx
+++ b/docs/integrations/audiobookshelf/index.mdx
@@ -1,0 +1,41 @@
+---
+title: 'Audiobookshelf'
+description: "Audiobookshelf is a self-hosted audiobook and podcast server that lets you manage and stream your audio library."
+hide_title: true
+---
+
+import { IntegrationHeader } from '@site/src/components/integrations/header';
+import { IntegrationCapabilites } from '@site/src/components/integrations/widgets';
+import { AddingIntegration } from '@site/src/components/integrations/adding';
+import { IntegrationSecrets } from '@site/src/components/integrations/secrets';
+import { audiobookshelfIntegration } from '.';
+import { audioStatsWidget } from '@site/docs/widgets/audio-stats';
+
+
+<IntegrationHeader
+    integration={audiobookshelfIntegration}
+    categories={['Media']}
+/>
+
+Audiobookshelf provides library statistics including audiobook and podcast counts, listening time, and active sessions.
+
+### Widgets & Capabilities
+<IntegrationCapabilites
+    items={[
+        { widget: audioStatsWidget },
+    ]}
+/>
+
+### Adding the integration
+<AddingIntegration />
+
+### Secrets
+<IntegrationSecrets secrets={[{
+    credentials: ['apiKey'],
+    steps: [
+        'Open your Audiobookshelf instance',
+        'Go to Settings → Users',
+        'Click on your user account',
+        'Copy the API token from the user details',
+    ]
+}]} />

--- a/docs/integrations/audiobookshelf/index.ts
+++ b/docs/integrations/audiobookshelf/index.ts
@@ -1,0 +1,9 @@
+import { IntegrationDefinition } from '@site/src/types';
+
+export const audiobookshelfIntegration: IntegrationDefinition = {
+  name: 'Audiobookshelf',
+  description:
+    'Audiobookshelf is a self-hosted audiobook and podcast server that lets you manage and stream your audio library.',
+  iconUrl: 'https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/audiobookshelf.svg',
+  path: '../../integrations/audiobookshelf',
+};

--- a/docs/integrations/navidrome/index.mdx
+++ b/docs/integrations/navidrome/index.mdx
@@ -1,0 +1,39 @@
+---
+title: 'Navidrome'
+description: "Navidrome is a self-hosted music server and streamer compatible with the Subsonic API."
+hide_title: true
+---
+
+import { IntegrationHeader } from '@site/src/components/integrations/header';
+import { IntegrationCapabilites } from '@site/src/components/integrations/widgets';
+import { AddingIntegration } from '@site/src/components/integrations/adding';
+import { IntegrationSecrets } from '@site/src/components/integrations/secrets';
+import { navidromeIntegration } from '.';
+import { audioStatsWidget } from '@site/docs/widgets/audio-stats';
+
+
+<IntegrationHeader
+    integration={navidromeIntegration}
+    categories={['Media']}
+/>
+
+Navidrome provides music library statistics including artist, album, and song counts, as well as now playing information via the Subsonic API.
+
+### Widgets & Capabilities
+<IntegrationCapabilites
+    items={[
+        { widget: audioStatsWidget },
+    ]}
+/>
+
+### Adding the integration
+<AddingIntegration />
+
+### Secrets
+<IntegrationSecrets secrets={[{
+    credentials: ['username', 'password'],
+    steps: [
+        'Use the same credentials you use to log in to Navidrome',
+        'The user must have access to the Subsonic API (enabled by default)',
+    ]
+}]} />

--- a/docs/integrations/navidrome/index.ts
+++ b/docs/integrations/navidrome/index.ts
@@ -1,0 +1,9 @@
+import { IntegrationDefinition } from '@site/src/types';
+
+export const navidromeIntegration: IntegrationDefinition = {
+  name: 'Navidrome',
+  description:
+    'Navidrome is a self-hosted music server and streamer compatible with the Subsonic API.',
+  iconUrl: 'https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/navidrome.svg',
+  path: '../../integrations/navidrome',
+};

--- a/docs/integrations/paperless-ngx/index.mdx
+++ b/docs/integrations/paperless-ngx/index.mdx
@@ -1,0 +1,41 @@
+---
+title: 'Paperless-ngx'
+description: "Paperless-ngx is a document management system that transforms your physical documents into a searchable online archive."
+hide_title: true
+---
+
+import { IntegrationHeader } from '@site/src/components/integrations/header';
+import { IntegrationCapabilites } from '@site/src/components/integrations/widgets';
+import { AddingIntegration } from '@site/src/components/integrations/adding';
+import { IntegrationSecrets } from '@site/src/components/integrations/secrets';
+import { paperlessNgxIntegration } from '.';
+import { paperlessNgxWidget } from '@site/docs/widgets/paperless-ngx';
+
+
+<IntegrationHeader
+    integration={paperlessNgxIntegration}
+    categories={['Documents']}
+/>
+
+Paperless-ngx provides document statistics including total documents, inbox count, correspondents, tags, and document types.
+
+### Widgets & Capabilities
+<IntegrationCapabilites
+    items={[
+        { widget: paperlessNgxWidget },
+    ]}
+/>
+
+### Adding the integration
+<AddingIntegration />
+
+### Secrets
+<IntegrationSecrets secrets={[{
+    credentials: ['apiKey'],
+    steps: [
+        'Open your Paperless-ngx instance',
+        'Navigate to Settings → Django Admin → Tokens',
+        'Create a new token for your user',
+        'Copy the token value',
+    ]
+}]} />

--- a/docs/integrations/paperless-ngx/index.ts
+++ b/docs/integrations/paperless-ngx/index.ts
@@ -1,0 +1,9 @@
+import { IntegrationDefinition } from '@site/src/types';
+
+export const paperlessNgxIntegration: IntegrationDefinition = {
+  name: 'Paperless-ngx',
+  description:
+    'Paperless-ngx is a document management system that transforms your physical documents into a searchable online archive.',
+  iconUrl: 'https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/paperless-ngx.svg',
+  path: '../../integrations/paperless-ngx',
+};

--- a/docs/integrations/uptime-kuma/index.mdx
+++ b/docs/integrations/uptime-kuma/index.mdx
@@ -1,0 +1,44 @@
+---
+title: 'Uptime Kuma'
+description: "Uptime Kuma is a self-hosted monitoring tool that tracks the availability of your services and websites."
+hide_title: true
+---
+
+import { IntegrationHeader } from '@site/src/components/integrations/header';
+import { IntegrationCapabilites } from '@site/src/components/integrations/widgets';
+import { AddingIntegration } from '@site/src/components/integrations/adding';
+import { IntegrationSecrets } from '@site/src/components/integrations/secrets';
+import { uptimeKumaIntegration } from '.';
+import { uptimeKumaWidget } from '@site/docs/widgets/uptime-kuma';
+
+
+<IntegrationHeader
+    integration={uptimeKumaIntegration}
+    categories={['Monitoring']}
+/>
+
+Uptime Kuma monitors the availability of your services and provides uptime statistics through its status page API.
+
+### Widgets & Capabilities
+<IntegrationCapabilites
+    items={[
+        { widget: uptimeKumaWidget },
+    ]}
+/>
+
+### Adding the integration
+<AddingIntegration />
+
+### Secrets
+<IntegrationSecrets secrets={[{
+    credentials: ['slug'],
+    steps: [
+        'Navigate to your Uptime Kuma instance',
+        'Go to Status Pages and create or select a status page',
+        'The slug is the URL path of your status page (e.g. "default" for /status/default)',
+    ]
+}]} />
+
+:::tip
+If you don't specify a slug, Homarr will use `default` as the status page slug.
+:::

--- a/docs/integrations/uptime-kuma/index.ts
+++ b/docs/integrations/uptime-kuma/index.ts
@@ -1,0 +1,9 @@
+import { IntegrationDefinition } from '@site/src/types';
+
+export const uptimeKumaIntegration: IntegrationDefinition = {
+  name: 'Uptime Kuma',
+  description:
+    'Uptime Kuma is a self-hosted monitoring tool that tracks the availability of your services and websites.',
+  iconUrl: 'https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/uptime-kuma.svg',
+  path: '../../integrations/uptime-kuma',
+};

--- a/docs/widgets/audio-stats/index.mdx
+++ b/docs/widgets/audio-stats/index.mdx
@@ -1,0 +1,43 @@
+---
+title: 'Audio Stats'
+description: 'Displays library statistics from Navidrome or Audiobookshelf, adapting its display based on the linked integration.'
+hide_title: true
+---
+
+import { WidgetHeader } from '@site/src/components/widgets/header';
+import { AddingWidget } from '@site/src/components/widgets/adding';
+import { WidgetConfig } from '@site/src/components/widgets/configuration';
+import { WidgetIntegrations } from '@site/src/components/widgets/integrations';
+import { audioStatsWidget } from '.';
+import { navidromeIntegration } from '@site/docs/integrations/navidrome';
+import { audiobookshelfIntegration } from '@site/docs/integrations/audiobookshelf';
+
+
+<WidgetHeader
+  widget={audioStatsWidget}
+  categories={['Media']}
+/>
+
+This widget adapts its display based on the linked integration:
+
+- **Navidrome**: Shows artist, album, and song counts, plus a now playing section with active streams
+- **Audiobookshelf**: Shows library count, audiobook/podcast totals, listening time, and active sessions
+
+Only options relevant to your linked integration are shown in the configuration panel.
+
+### Supported Integrations
+
+<WidgetIntegrations items={[{
+  integration: navidromeIntegration,
+  note: "Displays music library stats and now playing"
+}, {
+  integration: audiobookshelfIntegration,
+  note: "Displays audiobook/podcast library stats and listening time"
+}]} />
+
+### Adding the widget
+
+<AddingWidget />
+
+### Configuration
+<WidgetConfig configuration={audioStatsWidget.configuration} />

--- a/docs/widgets/audio-stats/index.ts
+++ b/docs/widgets/audio-stats/index.ts
@@ -1,0 +1,85 @@
+import { WidgetDefinition } from '@site/src/types';
+import { IconHeadphones } from '@tabler/icons-react';
+
+export const audioStatsWidget: WidgetDefinition = {
+  icon: IconHeadphones,
+  name: 'Audio Stats',
+  description: 'Displays library statistics from Navidrome or Audiobookshelf, adapting its display based on the linked integration.',
+  path: '../../widgets/audio-stats',
+  configuration: {
+    items: [
+      {
+        name: 'Show artists',
+        description: 'Displays the artist count (Navidrome only)',
+        values: { type: 'boolean' },
+        defaultValue: 'yes',
+      },
+      {
+        name: 'Show albums',
+        description: 'Displays the album count (Navidrome only)',
+        values: { type: 'boolean' },
+        defaultValue: 'yes',
+      },
+      {
+        name: 'Show songs',
+        description: 'Displays the song count (Navidrome only)',
+        values: { type: 'boolean' },
+        defaultValue: 'yes',
+      },
+      {
+        name: 'Show now playing',
+        description: 'Displays currently playing tracks (Navidrome only)',
+        values: { type: 'boolean' },
+        defaultValue: 'yes',
+      },
+      {
+        name: 'Show now playing list',
+        description: 'Displays a detailed list of now playing tracks (Navidrome only)',
+        values: { type: 'boolean' },
+        defaultValue: 'yes',
+      },
+      {
+        name: 'Max now playing items',
+        description: 'Maximum number of now playing tracks to display (Navidrome only)',
+        values: 'Number (1-5)',
+        defaultValue: '3',
+      },
+      {
+        name: 'Show library count',
+        description: 'Displays the number of libraries (Audiobookshelf only)',
+        values: { type: 'boolean' },
+        defaultValue: 'yes',
+      },
+      {
+        name: 'Show audiobooks',
+        description: 'Displays the total audiobook count (Audiobookshelf only)',
+        values: { type: 'boolean' },
+        defaultValue: 'yes',
+      },
+      {
+        name: 'Show podcasts',
+        description: 'Displays the total podcast count (Audiobookshelf only)',
+        values: { type: 'boolean' },
+        defaultValue: 'yes',
+      },
+      {
+        name: 'Show listening time',
+        description: 'Displays total listening time (Audiobookshelf only)',
+        values: { type: 'boolean' },
+        defaultValue: 'yes',
+      },
+      {
+        name: 'Show active sessions',
+        description: 'Displays the number of active listening sessions (Audiobookshelf only)',
+        values: { type: 'boolean' },
+        defaultValue: 'yes',
+      },
+      {
+        name: 'Compact mode',
+        description: 'Uses a more compact layout with smaller icons and tighter spacing',
+        values: { type: 'boolean' },
+        defaultValue: 'no',
+      },
+    ],
+  },
+};

--- a/docs/widgets/paperless-ngx/index.mdx
+++ b/docs/widgets/paperless-ngx/index.mdx
@@ -1,0 +1,34 @@
+---
+title: 'Paperless-ngx'
+description: 'Displays document management statistics including inbox ratio, document counts, and metadata.'
+hide_title: true
+---
+
+import { WidgetHeader } from '@site/src/components/widgets/header';
+import { AddingWidget } from '@site/src/components/widgets/adding';
+import { WidgetConfig } from '@site/src/components/widgets/configuration';
+import { WidgetIntegrations } from '@site/src/components/widgets/integrations';
+import { paperlessNgxWidget } from '.';
+import { paperlessNgxIntegration } from '@site/docs/integrations/paperless-ngx';
+
+
+<WidgetHeader
+  widget={paperlessNgxWidget}
+  categories={['Documents']}
+/>
+
+This widget displays statistics from your Paperless-ngx instance, including an inbox ratio ring showing how many documents are in your inbox versus total, along with counts for correspondents, tags, and document types.
+
+### Supported Integrations
+
+<WidgetIntegrations items={[{
+  integration: paperlessNgxIntegration,
+  note: "Displays document statistics and inbox ratio"
+}]} />
+
+### Adding the widget
+
+<AddingWidget />
+
+### Configuration
+<WidgetConfig configuration={paperlessNgxWidget.configuration} />

--- a/docs/widgets/paperless-ngx/index.ts
+++ b/docs/widgets/paperless-ngx/index.ts
@@ -1,0 +1,55 @@
+import { WidgetDefinition } from '@site/src/types';
+import { IconFileText } from '@tabler/icons-react';
+
+export const paperlessNgxWidget: WidgetDefinition = {
+  icon: IconFileText,
+  name: 'Paperless-ngx',
+  description: 'Displays document management statistics including inbox ratio, document counts, and metadata.',
+  path: '../../widgets/paperless-ngx',
+  configuration: {
+    items: [
+      {
+        name: 'Show inbox ratio',
+        description: 'Displays the inbox-to-total documents ratio as a hero section',
+        values: { type: 'boolean' },
+        defaultValue: 'yes',
+      },
+      {
+        name: 'Show inbox ring',
+        description: 'Displays a ring progress indicator for the inbox ratio',
+        values: { type: 'boolean' },
+        defaultValue: 'yes',
+      },
+      {
+        name: 'Show documents total',
+        description: 'Displays the total number of documents',
+        values: { type: 'boolean' },
+        defaultValue: 'yes',
+      },
+      {
+        name: 'Show documents inbox',
+        description: 'Displays the number of documents in the inbox',
+        values: { type: 'boolean' },
+        defaultValue: 'yes',
+      },
+      {
+        name: 'Show correspondents',
+        description: 'Displays the number of correspondents',
+        values: { type: 'boolean' },
+        defaultValue: 'yes',
+      },
+      {
+        name: 'Show tags',
+        description: 'Displays the number of tags',
+        values: { type: 'boolean' },
+        defaultValue: 'yes',
+      },
+      {
+        name: 'Show document types',
+        description: 'Displays the number of document types',
+        values: { type: 'boolean' },
+        defaultValue: 'yes',
+      },
+    ],
+  },
+};

--- a/docs/widgets/uptime-kuma/index.mdx
+++ b/docs/widgets/uptime-kuma/index.mdx
@@ -1,0 +1,34 @@
+---
+title: 'Uptime Kuma'
+description: 'Displays monitor uptime statistics, average uptime percentage, and service status counts.'
+hide_title: true
+---
+
+import { WidgetHeader } from '@site/src/components/widgets/header';
+import { AddingWidget } from '@site/src/components/widgets/adding';
+import { WidgetConfig } from '@site/src/components/widgets/configuration';
+import { WidgetIntegrations } from '@site/src/components/widgets/integrations';
+import { uptimeKumaWidget } from '.';
+import { uptimeKumaIntegration } from '@site/docs/integrations/uptime-kuma';
+
+
+<WidgetHeader
+  widget={uptimeKumaWidget}
+  categories={['Monitoring']}
+/>
+
+This widget displays uptime statistics from your Uptime Kuma status page, including a visual uptime ring, average uptime percentage, and per-status monitor counts.
+
+### Supported Integrations
+
+<WidgetIntegrations items={[{
+  integration: uptimeKumaIntegration,
+  note: "Displays monitors from the configured status page"
+}]} />
+
+### Adding the widget
+
+<AddingWidget />
+
+### Configuration
+<WidgetConfig configuration={uptimeKumaWidget.configuration} />

--- a/docs/widgets/uptime-kuma/index.ts
+++ b/docs/widgets/uptime-kuma/index.ts
@@ -1,0 +1,49 @@
+import { WidgetDefinition } from '@site/src/types';
+import { IconHeartbeat } from '@tabler/icons-react';
+
+export const uptimeKumaWidget: WidgetDefinition = {
+  icon: IconHeartbeat,
+  name: 'Uptime Kuma',
+  description: 'Displays monitor uptime statistics, average uptime percentage, and service status counts.',
+  path: '../../widgets/uptime-kuma',
+  configuration: {
+    items: [
+      {
+        name: 'Show average uptime',
+        description: 'Displays the average uptime percentage across all monitors',
+        values: { type: 'boolean' },
+        defaultValue: 'yes',
+      },
+      {
+        name: 'Show uptime ring',
+        description: 'Displays a ring progress indicator for average uptime',
+        values: { type: 'boolean' },
+        defaultValue: 'yes',
+      },
+      {
+        name: 'Show total monitors',
+        description: 'Displays the total number of monitors',
+        values: { type: 'boolean' },
+        defaultValue: 'yes',
+      },
+      {
+        name: 'Show up count',
+        description: 'Displays the number of monitors that are up',
+        values: { type: 'boolean' },
+        defaultValue: 'yes',
+      },
+      {
+        name: 'Show down count',
+        description: 'Displays the number of monitors that are down',
+        values: { type: 'boolean' },
+        defaultValue: 'yes',
+      },
+      {
+        name: 'Show paused count',
+        description: 'Displays the number of paused monitors',
+        values: { type: 'boolean' },
+        defaultValue: 'yes',
+      },
+    ],
+  },
+};


### PR DESCRIPTION
## Summary

Adds documentation for 4 new integrations and 3 new widgets, paired with [homarr-labs/homarr#5910](https://github.com/homarr-labs/homarr/pull/5910).

### New Integration Pages
- **Uptime Kuma** — monitoring, status page slug secret
- **Audiobookshelf** — media, API key secret  
- **Paperless-ngx** — documents, API token secret
- **Navidrome** — media, username/password (Subsonic API)

### New Widget Pages
- **Uptime Kuma** — uptime ring, monitor counts, average uptime
- **Audio Stats** — unified widget for Navidrome + Audiobookshelf with backend-adaptive options
- **Paperless-ngx** — inbox ratio ring, document/tag/correspondent stats

Each page follows the existing documentation patterns with `IntegrationHeader`, `IntegrationSecrets`, `WidgetHeader`, `WidgetConfig`, and `WidgetIntegrations` components.